### PR TITLE
fix: rtd build config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,3 +11,7 @@ mkdocs:
 python:
   install:
     - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - all


### PR DESCRIPTION
Install ecotrace package so mkdocstrings can parse modules