### PR TITLE
release: EcoTrace v1.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v4
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-07-01
+
+### Added
+- **`ecotrace diff` command**: Side-by-side carbon footprint comparison of any two runs.
+- **CSV Export options**: Extended `ecotrace export` with `--csv` format and `--run`/`--func` filters.
+- **Pausing API**: `EcoTrace.pause()` and `EcoTrace.resume()` for temporarily disabling carbon tracking during setup/teardown.
+- **`WebhookExporter`**: Push carbon metrics to webhooks in real-time (Slack, Teams, Discord, custom API).
+- **`ecotrace clean` command**: Rotate/cleanup log CSV by run count or date, creating a backup automatically.
+- **`ecotrace reset` command**: Reset/delete CSV log file completely with verification.
+
+### Fixed
+- **Duplicate Carbon Calculations**: Fixed duplicate and fragile carbon calculation in Keras and PyTorch callbacks.
+- **Empty GPU monitoring crash**: Guarded `EcoTraceML` shutdown sequence against empty GPU monitor histories.
+- **Async Metadata propagation**: Propagated source file paths and line numbers correctly in `measure_async()`.
+- **CPU Cache Optimization**: Reused cached CPU information query in `get_cpu_info` instead of repeating py-cpuinfo parsing.
+
+## [1.3.0] - 2026-06-13
+
+### Added
+- **Multi-Run Observability**: Unique Run ID and optional Run Label assigned to every session, written to CSV.
+- **Run commands**: CLI subcommands `ecotrace history` and `ecotrace trends` for multi-run history inspection.
+- **`get_summary()` API**: Programmatic session statistics for notebooks and test assertions.
+- **Apple Silicon Support**: Direct hardware energy counter monitoring via `powermetrics`.
+- **ML Framework Callbacks**: deferred callbacks `EcoTraceKerasCallback` and `EcoTracePyTorchCallback`.
+- **Live Browser Dashboard**: Real-time HTTP dashboard served via `ecotrace dashboard` on port 8585.
+
 ## [1.2.1] - 2026-06-03
 
 ### Fixed

--- a/README.MD
+++ b/README.MD
@@ -6,7 +6,7 @@
 
 ### High-Precision Energy and Emissions Instrumentation
 ---
-**v1.3.0 — Feature Release.** Multi-run history, programmatic `get_summary()` API, Apple Silicon energy monitoring, per-epoch ML callbacks, and a live browser dashboard — all with zero new mandatory dependencies.
+**v1.4.0 — Feature Release.** Pausable tracking API, WebhookExporter, side-by-side CLI diff comparison, filtered CSV exporting, and log maintenance commands — all with zero new mandatory dependencies.
 ---
 
 **EcoTrace is a lightweight library for granular carbon footprint measurement of Python applications. No configuration files, no background services—just real-time hardware-level transparency.**
@@ -38,17 +38,17 @@ Real-time monitoring | 50+ Global Zones | AI-powered insights | Zero-configurati
 
 ---
 
-## Core Features in v1.3.0
+## Core Features in v1.4.0
 
-> **Feature Release.** v1.3.0 adds multi-run observability, a programmatic summary API, Apple Silicon hardware energy reading, per-epoch ML callbacks, and a live browser dashboard.
+> **Feature Release.** v1.4.0 adds pausable tracking, side-by-side run comparisons, webhook integrations, filtered CSV exporting, and log rotation capabilities.
 
+- **Pausing API** — Temporarily disable carbon tracking using `EcoTrace.pause()` and `EcoTrace.resume()` to exclude setup and teardown overhead.
+- **Run Comparisons (`ecotrace diff`)** — Perform side-by-side carbon and execution duration comparisons between two specific runs.
+- **Webhook Integration (`WebhookExporter`)** — Stream carbon emissions data to Slack, Teams, Discord, or a custom API in real-time.
+- **Filtered CSV Exporting** — Export filtered subsets of measurement logs with `--csv` format and `--run`/`--func` filters.
+- **Log Maintenance Commands** — Rotate and trim logs via `ecotrace clean`, and permanently delete logs using `ecotrace reset`.
 - **Multi-Run History** — Every session gets a unique `RunID`. Use `ecotrace history` to compare runs and `ecotrace trends` for an ASCII carbon trend chart.
 - **`get_summary()` API** — Programmatic access to all session metrics as a typed dict. Ideal for notebooks, dashboards, and CI assertions.
-- **Apple Silicon Support** — Exact CPU energy readings via `powermetrics` on M-series Macs (falls back to Boavizta silently).
-- **Per-Epoch ML Callbacks** — `EcoTracePyTorchCallback` and `EcoTraceKerasCallback` log per-epoch carbon to CSV. PyTorch and TensorFlow are optional extras.
-- **Live Dashboard** — `ecotrace dashboard` serves a real-time browser UI on `localhost:8585`. Zero extra dependencies (stdlib only).
-- **EcoTraceML Tracking Engine** — A dedicated context manager and decorator for measuring carbon and energy footprint of ML model training sessions.
-- **Windows NVML Auto-Discovery** — Dynamically resolves and injects NVML DLL paths to prevent load errors on Windows platforms. See [CHANGELOG.md](CHANGELOG.md).
 
 ---
 

--- a/docs/history/releases/RELEASE_v1.4.0.md
+++ b/docs/history/releases/RELEASE_v1.4.0.md
@@ -1,0 +1,113 @@
+# Release Notes — v1.4.0
+
+**Released:** 2026-07-01
+**Type:** Feature Release — 6 new features, 5 bug fixes, zero breaking changes
+
+---
+
+## Summary
+
+v1.4.0 is a minor feature release introducing measurement pausing, webhook metrics exporting, side-by-side CLI run comparison (`ecotrace diff`), filtered CSV exporting, and log maintenance commands (`ecotrace clean` and `ecotrace reset`). It also fixes critical bug fixes related to ML callbacks, GPU monitor error handling, async source tracking, and CPU cache performance.
+
+---
+
+## New Features
+
+### 1. Pausable Tracking API (`pause()` / `resume()`)
+
+You can now pause and resume carbon tracking within an EcoTrace session to isolate your code's emissions from the overhead of setup, teardown, and data loaders.
+
+```python
+from ecotrace import EcoTrace
+
+eco = EcoTrace(region_code="TR")
+
+# Perform setup (unmeasured)
+eco.pause()
+expensive_setup_io()
+eco.resume()
+
+# Main processing block (measured)
+@eco.track
+def run_model():
+    ...
+```
+
+The paused duration is automatically subtracted from the total session duration reported in `get_summary()`.
+
+---
+
+### 2. Side-by-Side Run Comparisons (`ecotrace diff`)
+
+Compare any two tracking runs directly from the terminal to see if your code modifications reduced emissions.
+
+```bash
+# Compare two specific run IDs
+ecotrace diff abc123def456 789012abc345
+
+# Compare the latest two runs (CI/CD shortcut)
+ecotrace diff --latest
+```
+
+Outputs a comparison of:
+- Function call counts and delta
+- Execution duration and delta
+- Carbon emissions (gCO2) and delta (percentage and absolute)
+
+---
+
+### 3. Webhook Observability Exporter (`WebhookExporter`)
+
+A new exporter allows you to stream carbon data to Webhooks in real-time. Ideal for Slack, MS Teams, Discord, or custom backend API integration.
+
+```python
+from ecotrace import EcoTrace
+from ecotrace.exporters.webhook import WebhookExporter
+
+eco = EcoTrace(region_code="TR")
+WebhookExporter(eco, url="https://hooks.slack.com/services/...", headers={"Authorization": "Bearer token"})
+```
+
+---
+
+### 4. Filtered CSV Exporting
+
+We extended `ecotrace export` to output CSV files and filter output by Run ID/Label or Function Name.
+
+```bash
+# Export filtered CSV
+ecotrace export --csv -o filtered_run.csv --run abc123def456
+ecotrace export --csv -o test_funcs.csv --func "test_run"
+```
+
+---
+
+### 5. Log Maintenance (`ecotrace clean` & `ecotrace reset`)
+
+CLI utilities to manage log rotation and cleanup.
+
+```bash
+# Keep only the last 10 runs in ecotrace_log.csv (creates backup automatically)
+ecotrace clean --keep-runs 10
+
+# Delete entries before a specific date
+ecotrace clean --before 2026-06-01
+
+# Delete the log file entirely
+ecotrace reset --yes
+```
+
+---
+
+## Bug Fixes
+
+- **ML Callbacks Carbon Calculation:** Removed duplicate and fragile carbon calculation formulas in Keras and PyTorch callbacks, delegating directly to `EcoTraceML.log_epoch()` which now returns the exact computed value.
+- **Empty GPU monitoring crash:** Bypassed CSV log entries and PDF generation in `EcoTraceML` if `power_history` is empty.
+- **Async Hotspots:** Added `file_path` and `line_number` source lookup in `measure_async()`, restoring hotspot tracking in async functions.
+- **CPU caching performance:** Bypassed duplicate `cpuinfo.get_cpu_info()` calls in `cpu.py` by referencing the cached `fetch_raw_cpu_info()` directly.
+
+---
+
+## Upgrade Notes
+
+No breaking changes. Standard installation and execution continues working as expected.

--- a/ecotrace/__init__.py
+++ b/ecotrace/__init__.py
@@ -1,3 +1,3 @@
 from .core import EcoTrace
 from .ml import EcoTraceML, ecotrace_ml
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/ecotrace/callbacks/keras.py
+++ b/ecotrace/callbacks/keras.py
@@ -142,11 +142,7 @@ class EcoTraceKerasCallback:
 
         # Pass Keras logs as metrics so loss appears in the CSV label
         metrics = dict(logs) if logs else {}
-        self._tracker.log_epoch(epoch, epoch_energy_j, epoch_duration, metrics)
-
-        gpu_kwh = epoch_energy_j / 3_600_000.0
-        raw_intensity = getattr(self._tracker.eco, "carbon_intensity", 0.475)
-        carbon_g = (gpu_kwh * (raw_intensity * 1000.0 if raw_intensity < 10 else raw_intensity)) * 1.05
+        carbon_g = self._tracker.log_epoch(epoch, epoch_energy_j, epoch_duration, metrics)
 
         self._epoch_results.append((epoch, carbon_g, epoch_duration))
 

--- a/ecotrace/callbacks/pytorch.py
+++ b/ecotrace/callbacks/pytorch.py
@@ -108,12 +108,7 @@ class EcoTracePyTorchCallback:
         current_energy_j, _ = self._tracker.snapshot_energy()
         epoch_energy_j = max(0.0, current_energy_j - self._epoch_start_energy_j)
 
-        self._tracker.log_epoch(epoch, epoch_energy_j, epoch_duration, metrics)
-
-        # Carbon estimate for console output
-        gpu_kwh = epoch_energy_j / 3_600_000.0
-        raw_intensity = getattr(self._tracker.eco, "carbon_intensity", 0.475)
-        carbon_g = (gpu_kwh * (raw_intensity * 1000.0 if raw_intensity < 10 else raw_intensity)) * 1.05
+        carbon_g = self._tracker.log_epoch(epoch, epoch_energy_j, epoch_duration, metrics)
 
         self._epoch_results.append((epoch, carbon_g, epoch_duration))
 

--- a/ecotrace/cli.py
+++ b/ecotrace/cli.py
@@ -281,32 +281,283 @@ def _cmd_analyze(args):
 # VS Code extension will consume this JSON for its sidebar dashboard.
 
 def _cmd_export(args):
-    """Exports session data to JSON format for external tool consumption.
-
-    Creates a structured JSON file containing hardware metadata,
-    measurement history, and aggregate statistics.
-
-    Args:
-        args: Parsed argparse namespace with ``output`` and ``format`` options.
-    """
+    """Exports session data to JSON or CSV format with filters."""
     _print_banner()
 
-    if args.format != "json":
+    if args.format not in ("json", "csv"):
         print(f"[ERROR] Unsupported format: {args.format}")
-        print("[INFO]  Currently only JSON is supported: ecotrace export --json")
         sys.exit(1)
 
+    csv_path = getattr(args, "file", "ecotrace_log.csv")
     output_path = args.output
 
-    # Initialize EcoTrace quietly just for hardware metadata
-    from ecotrace.core import EcoTrace
-    eco = EcoTrace(check_updates=False, quiet=True)
+    if args.format == "json":
+        from ecotrace.core import EcoTrace
+        eco = EcoTrace(check_updates=False, quiet=True)
+        try:
+            eco.export_json(output_path, csv_path=csv_path)
+            print(f"[EXPORT] JSON report created successfully: {output_path}")
+        except Exception as e:
+            print(f"[ERROR] JSON export failed: {e}")
+            sys.exit(1)
+    elif args.format == "csv":
+        if not os.path.isfile(csv_path):
+            print(f"[ERROR] Log file not found: {csv_path}")
+            sys.exit(1)
+
+        try:
+            filtered_rows = []
+            headers = []
+            with open(csv_path, "r", encoding="utf-8") as f:
+                reader = csv.reader(f)
+                try:
+                    headers = next(reader)
+                except StopIteration:
+                    headers = []
+
+                if headers:
+                    func_idx = headers.index("Function") if "Function" in headers else -1
+                    run_id_idx = headers.index("RunID") if "RunID" in headers else -1
+                    run_lbl_idx = headers.index("RunLabel") if "RunLabel" in headers else -1
+
+                    for row in reader:
+                        # Apply filters
+                        if args.run:
+                            row_run_id = row[run_id_idx] if run_id_idx < len(row) else ""
+                            row_run_lbl = row[run_lbl_idx] if run_lbl_idx < len(row) else ""
+                            if args.run != row_run_id and args.run != row_run_lbl:
+                                continue
+                        if args.func:
+                            row_func = row[func_idx] if func_idx < len(row) else ""
+                            if args.func != row_func:
+                                continue
+                        filtered_rows.append(row)
+
+            with open(output_path, "w", newline="", encoding="utf-8") as f:
+                writer = csv.writer(f)
+                if headers:
+                    writer.writerow(headers)
+                writer.writerows(filtered_rows)
+
+            print(f"[EXPORT] Filtered CSV report written: {output_path} ({len(filtered_rows)} records)")
+        except Exception as e:
+            print(f"[ERROR] CSV export failed: {e}")
+            sys.exit(1)
+
+
+def _cmd_diff(args):
+    """Compares carbon emissions of two runs side-by-side."""
+    csv_path = args.file
+    _print_banner()
+
+    if not os.path.isfile(csv_path):
+        print(f"[ERROR] Log file not found: {csv_path}")
+        sys.exit(1)
+
+    # Aggregate data by RunID
+    run_map = {}
+    try:
+        with open(csv_path, "r", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                try:
+                    carbon = float(row.get("Carbon(gCO2)", 0))
+                    duration = float(row.get("Duration(s)", 0))
+                except (ValueError, TypeError):
+                    continue
+
+                run_id = row.get("RunID", "").strip() or "legacy"
+                run_label = row.get("RunLabel", "").strip()
+                date = row.get("Date", "")
+
+                if run_id not in run_map:
+                    run_map[run_id] = {
+                        "run_id": run_id,
+                        "label": run_label,
+                        "date": date,
+                        "count": 0,
+                        "duration_s": 0.0,
+                        "carbon_gco2": 0.0,
+                    }
+                r = run_map[run_id]
+                r["count"] += 1
+                r["duration_s"] += duration
+                r["carbon_gco2"] += carbon
+                if date > r["date"]:
+                    r["date"] = date
+    except Exception as e:
+        print(f"[ERROR] CSV read error: {e}")
+        sys.exit(1)
+
+    if not run_map:
+        print("[INFO] No runs found in log.")
+        return
+
+    sorted_runs = sorted(run_map.values(), key=lambda x: x["date"])
+
+    run_id1 = None
+    run_id2 = None
+
+    if args.latest:
+        if len(sorted_runs) < 2:
+            print("[ERROR] At least 2 runs are required to perform a comparison.")
+            sys.exit(1)
+        run_id1 = sorted_runs[-2]["run_id"]
+        run_id2 = sorted_runs[-1]["run_id"]
+    else:
+        if not args.run_ids or len(args.run_ids) != 2:
+            print("[ERROR] Please specify exactly two Run IDs or use --latest.")
+            sys.exit(1)
+        run_id1, run_id2 = args.run_ids
+
+    if run_id1 not in run_map:
+        print(f"[ERROR] Run ID not found: {run_id1}")
+        sys.exit(1)
+    if run_id2 not in run_map:
+        print(f"[ERROR] Run ID not found: {run_id2}")
+        sys.exit(1)
+
+    r1 = run_map[run_id1]
+    r2 = run_map[run_id2]
+
+    diff_carbon = r2["carbon_gco2"] - r1["carbon_gco2"]
+    diff_duration = r2["duration_s"] - r1["duration_s"]
+    diff_funcs = r2["count"] - r1["count"]
+
+    pct_carbon = (diff_carbon / r1["carbon_gco2"] * 100) if r1["carbon_gco2"] > 0 else 0.0
+    pct_duration = (diff_duration / r1["duration_s"] * 100) if r1["duration_s"] > 0 else 0.0
+    pct_funcs = (diff_funcs / r1["count"] * 100) if r1["count"] > 0 else 0.0
+
+    print("=" * 72)
+    print("  EcoTrace — Run Comparison Report")
+    print("=" * 72)
+    print(f"  {'Metric':<15} | {'Base (Run 1)':<24} | {'Target (Run 2)':<24}")
+    print(f"  {'':<15} | {run_id1:<24} | {run_id2:<24}")
+    print(f"  {'Label':<15} | {r1['label']:<24} | {r2['label']:<24}")
+    print(f"  {'Date':<15} | {r1['date']:<24} | {r2['date']:<24}")
+    print("-" * 72)
+    
+    sign_c = "+" if diff_carbon >= 0 else ""
+    sign_d = "+" if diff_duration >= 0 else ""
+    sign_f = "+" if diff_funcs >= 0 else ""
+
+    print(f"  {'Functions':<15} | {r1['count']:<24} | {r2['count']:<24}")
+    print(f"  {'Delta (Funcs)':<15} | {sign_f}{diff_funcs} ({sign_f}{pct_funcs:.1f}%)")
+    print("-" * 72)
+    print(f"  {'Duration':<15} | {r1['duration_s']:<20.4f} s | {r2['duration_s']:<20.4f} s")
+    print(f"  {'Delta (Time)':<15} | {sign_d}{diff_duration:.4f} s ({sign_d}{pct_duration:.1f}%)")
+    print("-" * 72)
+    print(f"  {'Carbon (CO2)':<15} | {r1['carbon_gco2']:<20.8f} g | {r2['carbon_gco2']:<20.8f} g")
+    print(f"  {'Delta (CO2)':<15} | {sign_c}{diff_carbon:.8f} g ({sign_c}{pct_carbon:.1f}%)")
+    print("=" * 72)
+
+
+def _cmd_clean(args):
+    """Trims the CSV audit log by run count or date, creating a backup first."""
+    csv_path = args.file
+    _print_banner()
+
+    if not os.path.isfile(csv_path):
+        print(f"[ERROR] Log file not found: {csv_path}")
+        sys.exit(1)
+
+    import shutil
+    backup_path = csv_path + ".bak"
+    try:
+        shutil.copy(csv_path, backup_path)
+        print(f"[CLEAN] Backup created: {backup_path}")
+    except Exception as e:
+        print(f"[ERROR] Could not create backup file: {e}")
+        sys.exit(1)
 
     try:
-        eco.export_json(output_path)
-        print(f"[EXPORT] JSON report created successfully: {output_path}")
+        rows = []
+        headers = []
+        with open(csv_path, "r", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            headers = reader.fieldnames
+            for row in reader:
+                rows.append(row)
     except Exception as e:
-        print(f"[ERROR] JSON export failed: {e}")
+        print(f"[ERROR] CSV read failed: {e}")
+        sys.exit(1)
+
+    if not rows:
+        print("[INFO] Log file is empty. Nothing to clean.")
+        return
+
+    original_count = len(rows)
+
+    # Filter 1: --before DATE
+    if args.before:
+        filtered_rows = []
+        for row in rows:
+            date_str = row.get("Date", "")
+            cmp_len = len(args.before)
+            if date_str[:cmp_len] < args.before:
+                continue
+            filtered_rows.append(row)
+        rows = filtered_rows
+
+    # Filter 2: --keep-runs N
+    if args.keep_runs is not None:
+        if args.keep_runs <= 0:
+            print("[ERROR] --keep-runs must be a positive integer.")
+            sys.exit(1)
+
+        run_dates = {}
+        for row in rows:
+            run_id = row.get("RunID", "").strip() or "legacy"
+            date = row.get("Date", "")
+            if run_id not in run_dates or date > run_dates[run_id]:
+                run_dates[run_id] = date
+
+        sorted_runs = sorted(run_dates.keys(), key=lambda r: run_dates[r])
+        kept_runs = set(sorted_runs[-args.keep_runs:])
+
+        filtered_rows = []
+        for row in rows:
+            run_id = row.get("RunID", "").strip() or "legacy"
+            if run_id in kept_runs:
+                filtered_rows.append(row)
+        rows = filtered_rows
+
+    try:
+        with open(csv_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=headers)
+            writer.writeheader()
+            writer.writerows(rows)
+        print(f"[CLEAN] Trimmed {original_count - len(rows)} entries. {len(rows)} remaining.")
+    except Exception as e:
+        print(f"[ERROR] Failed to write trimmed CSV: {e}")
+        sys.exit(1)
+
+
+def _cmd_reset(args):
+    """Deletes the CSV log file entirely after confirmation."""
+    csv_path = args.file
+    _print_banner()
+
+    if not os.path.exists(csv_path):
+        print(f"[RESET] Log file does not exist: {csv_path}")
+        return
+
+    if not args.yes:
+        print("WARNING: This will permanently delete the carbon emission log file!")
+        try:
+            confirm = input("Are you sure you want to proceed? (y/n): ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print("\nReset cancelled.")
+            sys.exit(1)
+        if confirm != "y":
+            print("Reset cancelled.")
+            return
+
+    try:
+        os.remove(csv_path)
+        print(f"[RESET] Successfully deleted {csv_path}")
+    except Exception as e:
+        print(f"[ERROR] Failed to delete log file: {e}")
         sys.exit(1)
 
 
@@ -749,11 +1000,16 @@ def main():
     # --- export ---
     export_parser = subparsers.add_parser(
         "export",
-        help="Export session data to JSON format",
-        description="Export hardware info and measurement history as JSON."
+        help="Export session data to JSON or CSV format",
+        description="Export hardware info and measurement history as JSON, or filtered CSV."
     )
     export_parser.add_argument("--json", dest="format", action="store_const", const="json", default="json",
                                help="Export in JSON format (default)")
+    export_parser.add_argument("--csv", dest="format", action="store_const", const="csv",
+                               help="Export in CSV format")
+    export_parser.add_argument("-f", "--file", default="ecotrace_log.csv", help="Path to source CSV log file")
+    export_parser.add_argument("--run", default=None, help="Filter export by Run ID or Run Label")
+    export_parser.add_argument("--func", default=None, help="Filter export by function name")
     export_parser.add_argument("-o", "--output", default="ecotrace_report.json", help="Output file path")
 
     # --- benchmark ---
@@ -819,6 +1075,35 @@ def main():
     optimize_parser.add_argument("--func", required=True, help="Name of the function to optimize")
     optimize_parser.add_argument("--region", default="GLOBAL", help="ISO region code for context")
 
+    # --- diff ---
+    diff_parser = subparsers.add_parser(
+        "diff",
+        help="Compare two runs side-by-side",
+        description="Compare carbon emissions and duration between two runs."
+    )
+    diff_parser.add_argument("run_ids", nargs="*", help="Exactly two Run IDs to compare")
+    diff_parser.add_argument("--latest", action="store_true", help="Compare the latest two runs")
+    diff_parser.add_argument("-f", "--file", default="ecotrace_log.csv", help="Path to CSV log file")
+
+    # --- clean ---
+    clean_parser = subparsers.add_parser(
+        "clean",
+        help="Trim the CSV log file by date or run count",
+        description="Rotate/cleanup CSV logs by removing old runs."
+    )
+    clean_parser.add_argument("--keep-runs", type=int, default=None, help="Number of latest runs to keep")
+    clean_parser.add_argument("--before", default=None, help="Remove entries older than YYYY-MM-DD")
+    clean_parser.add_argument("-f", "--file", default="ecotrace_log.csv", help="Path to CSV log file")
+
+    # --- reset ---
+    reset_parser = subparsers.add_parser(
+        "reset",
+        help="Delete the CSV log file entirely",
+        description="Delete ecotrace_log.csv after confirmation."
+    )
+    reset_parser.add_argument("-y", "--yes", action="store_true", help="Skip confirmation prompt")
+    reset_parser.add_argument("-f", "--file", default="ecotrace_log.csv", help="Path to CSV log file")
+
     # --- Parse & Dispatch ---
     args = parser.parse_args()
 
@@ -837,6 +1122,9 @@ def main():
         "history": _cmd_history,
         "trends": _cmd_trends,
         "dashboard": _cmd_dashboard,
+        "diff": _cmd_diff,
+        "clean": _cmd_clean,
+        "reset": _cmd_reset,
     }
 
     handler = commands.get(args.command)

--- a/ecotrace/config.py
+++ b/ecotrace/config.py
@@ -10,7 +10,7 @@ try:
     from ecotrace import __version__ as _pkg_version
     USER_AGENT = f"EcoTrace/{_pkg_version}"
 except ImportError:
-    USER_AGENT = "EcoTrace/1.3.0"
+    USER_AGENT = "EcoTrace/1.4.0"
 
 def load_constants(json_path):
     """Loads constants from the JSON configuration file.

--- a/ecotrace/core.py
+++ b/ecotrace/core.py
@@ -185,6 +185,9 @@ class EcoTrace:
         # overhead; lower frequency (like 15s) misses bursty micro-code.
         self._monitor_interval = self.MONITOR_INTERVAL_S
         self._current_process = psutil.Process()
+        self._paused = False
+        self._paused_at = None
+        self._total_paused_duration = 0.0
 
         # --- Initialization Sequence (v0.7.0) -------------------------------
         if not self.quiet:
@@ -383,14 +386,18 @@ class EcoTrace:
             line_number: Line number where the function is defined.
         """
         with self._carbon_lock:
+            if self._paused:
+                return
             self.total_carbon += carbon_emitted
             self._tracked_functions_count += 1
             self._log_to_csv(func_name, duration, carbon_emitted, avg_cpu, file_path, line_number)
 
             # --- Emit to registered telemetry exporters ----------------------
             if self._exporters:
-                def _dispatch_exporters():
-                    for exporter in self._exporters:
+                exporters = list(self._exporters)
+
+                def _dispatch_exporters(exporters=exporters):
+                    for exporter in exporters:
                         try:
                             exporter.export(
                                 carbon_emitted=carbon_emitted,
@@ -400,11 +407,14 @@ class EcoTrace:
                             )
                         except Exception as e:
                             logger.debug(f"EcoTrace Exporter error: {e}")
-                self._exporter_pool.submit(_dispatch_exporters)
+
+                try:
+                    self._exporter_pool.submit(_dispatch_exporters)
+                except Exception as e:
+                    logger.debug(f"EcoTrace Exporter pool unavailable, falling back to synchronous dispatch: {e}")
+                    _dispatch_exporters()
 
             # --- Carbon Budget Enforcement (v1.0) ----------------------------
-            # The library enforces its own rules. If a limit was set, we check
-            # it here — not in the IDE, not in middleware, right at the source.
             self._enforce_carbon_budget(func_name)
 
     def add_exporter(self, exporter):
@@ -471,6 +481,24 @@ class EcoTrace:
             return None
         return max(0.0, self.carbon_limit - self.total_carbon)
 
+    def pause(self):
+        """Temporarily pauses carbon tracking for the session."""
+        with self._carbon_lock:
+            if not self._paused:
+                self._paused = True
+                self._paused_at = time.perf_counter()
+                logger.info("[EcoTrace] Instrumentation session paused.")
+
+    def resume(self):
+        """Resumes carbon tracking for the session."""
+        with self._carbon_lock:
+            if self._paused:
+                self._paused = False
+                if self._paused_at is not None:
+                    self._total_paused_duration += time.perf_counter() - self._paused_at
+                    self._paused_at = None
+                logger.info("[EcoTrace] Instrumentation session resumed.")
+
     def get_summary(self) -> dict:
         """Returns the current session metrics as a structured dictionary.
 
@@ -493,6 +521,10 @@ class EcoTrace:
                 - ``hardware``: CPU/GPU/energy sensor metadata dict.
         """
         session_duration = time.perf_counter() - self._session_start_time
+        current_pause = 0.0
+        if self._paused and self._paused_at is not None:
+            current_pause = time.perf_counter() - self._paused_at
+        active_duration = max(0.0, session_duration - self._total_paused_duration - current_pause)
 
         # Determine energy sensor label
         if self.hardware.rapl_available:
@@ -516,7 +548,7 @@ class EcoTrace:
         return {
             "run_id": self._run_id,
             "run_label": self._run_label,
-            "duration_s": round(session_duration, 4),
+            "duration_s": round(active_duration, 4),
             "functions_tracked": self._tracked_functions_count,
             "total_carbon_gco2": self.total_carbon,
             "region": self.region_code,
@@ -803,6 +835,20 @@ class EcoTrace:
             # Floor at 0 to avoid negative utilization from measurement jitter.
             return max(0.0, normalized - self._idle_baseline_pct)
 
+    def _get_source_location(self, func):
+        """Returns the source file path and line number for a callable.
+
+        Works for wrapped, decorated, and async functions by unwrapping the
+        original implementation before querying inspect.
+        """
+        try:
+            target = inspect.unwrap(func)
+            file_path = os.path.abspath(inspect.getfile(target))
+            line_number = inspect.getsourcelines(target)[1]
+            return file_path, line_number
+        except Exception:
+            return None, None
+
     def _get_avg_gpu_in_range(self, start_time, end_time):
         """Computes mean GPU utilization and power from samples within a time window.
 
@@ -1028,12 +1074,8 @@ class EcoTrace:
                 with self._cpu_sample_lock:
                     measurement_samples = list(self._cpu_samples)
 
-                # Capture location info
-                try:
-                    file_path = os.path.abspath(inspect.getfile(func))
-                    line_number = inspect.getsourcelines(func)[1]
-                except Exception:
-                    file_path, line_number = None, None
+                # Capture location info robustly for decorated and async functions
+                file_path, line_number = self._get_source_location(func)
 
                 energy_delta_j = None
                 if energy_start is not None and energy_end is not None:
@@ -1115,8 +1157,11 @@ class EcoTrace:
                 if energy_start is not None and energy_end is not None:
                     energy_delta_j = max(0.0, energy_end - energy_start)
 
+                # Capture location info robustly for decorated and async functions
+                file_path, line_number = self._get_source_location(func)
+
                 carbon_emitted = self._compute_carbon(self.cpu_info['tdp'], avg_cpu, duration, energy_delta_j=energy_delta_j)
-                self._accumulate_carbon(carbon_emitted, func.__name__, duration, avg_cpu)
+                self._accumulate_carbon(carbon_emitted, func.__name__, duration, avg_cpu, file_path=file_path, line_number=line_number)
 
                 if func_success:
                     return {

--- a/ecotrace/cpu.py
+++ b/ecotrace/cpu.py
@@ -57,7 +57,7 @@ def get_cpu_info(tdp_db, constants_data):
             - cores (int): Count of logical processing threads utilizing the OS scheduler.
             - tdp (float): Assigned structural TDP boundary in watts.
     """
-    info = cpuinfo.get_cpu_info()
+    info = fetch_raw_cpu_info()
     brand = info.get("brand_raw", "Unknown CPU")
     
     display_brand = "".join(c for c in brand if ord(c) < 128).replace("(R)", "").replace("(TM)", "").replace("(r)", "").replace("(tm)", "")

--- a/ecotrace/exporters/__init__.py
+++ b/ecotrace/exporters/__init__.py
@@ -6,5 +6,6 @@ observability platforms and telemetry aggregators.
 """
 
 from .otel import OTelExporter
+from .webhook import WebhookExporter
 
-__all__ = ["OTelExporter"]
+__all__ = ["OTelExporter", "WebhookExporter"]

--- a/ecotrace/exporters/webhook.py
+++ b/ecotrace/exporters/webhook.py
@@ -1,0 +1,72 @@
+import logging
+import json
+from typing import Dict, Any, Optional
+
+logger = logging.getLogger("ecotrace.exporters.webhook")
+
+try:
+    import requests  # type: ignore
+except ImportError:
+    requests = None
+
+from ecotrace.core import EcoTrace
+
+class WebhookExporter:
+    """Webhook metrics exporter for EcoTrace carbon emissions.
+    
+    Sends a POST request to a configurable webhook URL whenever a measurement completes.
+    
+    Args:
+        ecotrace_instance: The initialized EcoTrace core instance to attach to.
+        url: The webhook HTTP/HTTPS endpoint.
+        headers: Optional dict of extra HTTP headers (e.g. for auth/tokens).
+    """
+    
+    def __init__(
+        self, 
+        ecotrace_instance: EcoTrace, 
+        url: str,
+        headers: Optional[Dict[str, str]] = None
+    ):
+        if requests is None:
+            msg = "WebhookExporter requires 'requests'. Please install requests."
+            logger.error(msg)
+            self.url = None
+            return
+            
+        self.ecotrace = ecotrace_instance
+        self.url = url
+        self.headers = headers or {}
+        
+        # Attach self to the EcoTrace engine
+        self.ecotrace.add_exporter(self)
+        logger.info(f"Webhook Exporter attached to EcoTrace (url: {self.url}).")
+
+    def export(self, carbon_emitted: float, func_name: str, duration: float, region: str):
+        """Called synchronously by EcoTrace whenever a measurement completes.
+        
+        Args:
+            carbon_emitted: The measured footprint in gCO2.
+            func_name: The name of the function or block that was tracked.
+            duration: The execution time in seconds.
+            region: The grid intensity region code used (e.g., 'US', 'DE').
+        """
+        if not self.url or requests is None:
+            return
+            
+        payload = {
+            "function": func_name,
+            "carbon_gco2": carbon_emitted,
+            "duration_s": duration,
+            "region": region,
+            "run_id": getattr(self.ecotrace, "_run_id", ""),
+            "run_label": getattr(self.ecotrace, "_run_label", "")
+        }
+        
+        try:
+            req_headers = {"Content-Type": "application/json"}
+            req_headers.update(self.headers)
+            response = requests.post(self.url, json=payload, headers=req_headers, timeout=5)
+            response.raise_for_status()
+        except Exception as e:
+            logger.debug(f"Failed to send webhook metric: {e}")

--- a/ecotrace/ml.py
+++ b/ecotrace/ml.py
@@ -30,6 +30,18 @@ class EcoTraceML:
         self.gpu_index = self.eco.gpu_index if self.eco.gpu_index is not None else gpu_index
         self._epoch_snapshots = []  # List of per-epoch (energy_j, duration_s) snapshots
 
+    def _carbon_intensity_gco2_per_kwh(self):
+        """Normalize carbon intensity to gCO2/kWh.
+
+        Some legacy or misconfigured intensity values can be expressed in
+        kgCO2/kWh. The main EcoTrace engine uses gCO2/kWh, so we normalize
+        values below 10 as kgCO2/kWh to preserve backward compatibility.
+        """
+        raw_intensity = getattr(self.eco, "carbon_intensity", 475.0)
+        if raw_intensity <= 0.0:
+            return 475.0
+        return raw_intensity * 1000.0 if raw_intensity < 10.0 else raw_intensity
+
     def _monitor_gpu(self):
         last_time = time.time()
 
@@ -74,8 +86,7 @@ class EcoTraceML:
             metrics: Optional dict of framework metrics (e.g. ``{'loss': 0.42}``).
         """
         gpu_kwh = energy_j / 3_600_000.0
-        raw_intensity = getattr(self.eco, "carbon_intensity", 0.475)
-        carbon_intensity_g = raw_intensity * 1000.0 if raw_intensity < 10.0 else raw_intensity
+        carbon_intensity_g = self._carbon_intensity_gco2_per_kwh()
         co2_g = (gpu_kwh * carbon_intensity_g) * 1.05  # 5 % ISO uncertainty margin
         region_str = getattr(self.eco, "region_code", "GLOBAL")
         run_id = getattr(self.eco, "_run_id", "")
@@ -107,6 +118,7 @@ class EcoTraceML:
                 ])
         except Exception as e:
             print(f"[EcoTraceML] Could not write epoch log: {e}")
+        return co2_g
 
     def __enter__(self):
         if self.gpu_info and self.gpu_info.get('brand') != 'Unknown':
@@ -132,9 +144,12 @@ class EcoTraceML:
             total_gpu_energy_joules = self.total_gpu_energy_joules
             power_history = list(self.power_history)
 
+        if not power_history:
+            print(f"[EcoTraceML] No energy monitoring data collected for {self.model_name}.")
+            return False
+
         gpu_kwh = total_gpu_energy_joules / 3600000.0
-        raw_intensity = getattr(self.eco, "carbon_intensity", 0.475)
-        carbon_intensity_g = raw_intensity * 1000.0 if raw_intensity < 10.0 else raw_intensity
+        carbon_intensity_g = self._carbon_intensity_gco2_per_kwh()
         co2_emitted_g_iso = (gpu_kwh * carbon_intensity_g) * 1.05
 
         # Update core cumulative trackers if they exist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ecotrace"
-version = "1.3.0"
+version = "1.4.0"
 description = "EcoTrace: High-precision carbon tracking engine for production Python. Function-level CPU/GPU emission measurement with 50ms continuous sampling, Boavizta TDP database, and audit-ready PDF reporting."
 keywords = ["carbon-footprint", "energy-efficiency", "green-computing", "sustainability", "metrics", "cpu-monitoring", "gpu-monitoring"]
 classifiers = [

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -26,6 +26,7 @@ def test_pytorch_callback_lifecycle(capsys):
     mock_tracker = MagicMock()
     mock_tracker.gpu_info = {"brand": "Test NVIDIA GPU"}
     mock_tracker.snapshot_energy.return_value = (5000.0, [])
+    mock_tracker.log_epoch.return_value = 0.0001
     mock_tracker.eco = MagicMock()
     mock_tracker.eco.carbon_intensity = 0.5
 
@@ -69,6 +70,7 @@ def test_keras_callback_lifecycle(capsys):
     mock_tracker = MagicMock()
     mock_tracker.gpu_info = {"brand": "Test AMD GPU"}
     mock_tracker.snapshot_energy.return_value = (1000.0, [])
+    mock_tracker.log_epoch.return_value = 0.0001
     mock_tracker.eco = MagicMock()
     mock_tracker.eco.carbon_intensity = 0.4
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,7 +68,7 @@ def test_cli_export_success(mock_export, capsys):
         format = "json"
         output = "test_out.json"
     _cmd_export(Args())
-    mock_export.assert_called_once_with("test_out.json")
+    mock_export.assert_called_once()
     captured = capsys.readouterr()
     assert "[EXPORT] JSON report created successfully" in captured.out
 
@@ -151,4 +151,90 @@ def test_cli_dashboard_success(mock_server):
     
     mock_server.assert_called_once_with(csv_path="dummy_log.csv", port=9000)
     mock_server.return_value.serve_forever.assert_called_once()
+
+def test_cli_export_csv(tmp_path, capsys):
+    csv_file = tmp_path / "export_test_log.csv"
+    csv_file.write_text(
+        "Date,Function,Duration(s),Carbon(gCO2),Region,AvgCPU(%),FilePath,Line,RunID,RunLabel\n"
+        "2026-06-13 12:00,func_a,1.5,0.25,TR,10.0,dummy.py,1,run1,label1\n"
+        "2026-06-13 12:05,func_b,2.0,0.75,TR,12.0,dummy.py,5,run2,label2\n"
+    )
+    out_file = tmp_path / "filtered_out.csv"
+    
+    class Args:
+        format = "csv"
+        file = str(csv_file)
+        output = str(out_file)
+        run = "run1"
+        func = None
+        
+    from ecotrace.cli import _cmd_export
+    _cmd_export(Args())
+    captured = capsys.readouterr()
+    assert "Filtered CSV report written" in captured.out
+    
+    # Read output and verify it is filtered
+    content = out_file.read_text()
+    assert "func_a" in content
+    assert "func_b" not in content
+
+def test_cli_diff_success(tmp_path, capsys):
+    csv_file = tmp_path / "diff_test_log.csv"
+    csv_file.write_text(
+        "Date,Function,Duration(s),Carbon(gCO2),Region,AvgCPU(%),FilePath,Line,RunID,RunLabel\n"
+        "2026-06-13 12:00,func_a,1.0,0.20,TR,10.0,dummy.py,1,run1,label1\n"
+        "2026-06-13 12:05,func_b,2.0,0.30,TR,12.0,dummy.py,5,run2,label2\n"
+    )
+    
+    class Args:
+        file = str(csv_file)
+        run_ids = ["run1", "run2"]
+        latest = False
+        
+    from ecotrace.cli import _cmd_diff
+    _cmd_diff(Args())
+    captured = capsys.readouterr()
+    assert "EcoTrace — Run Comparison Report" in captured.out
+    assert "run1" in captured.out
+    assert "run2" in captured.out
+    assert "+0.10000000" in captured.out # carbon delta
+
+def test_cli_clean_success(tmp_path, capsys):
+    csv_file = tmp_path / "clean_test_log.csv"
+    csv_file.write_text(
+        "Date,Function,Duration(s),Carbon(gCO2),Region,AvgCPU(%),FilePath,Line,RunID,RunLabel\n"
+        "2026-06-11 12:00,func_a,1.0,0.20,TR,10.0,dummy.py,1,run1,label1\n"
+        "2026-06-12 12:00,func_b,2.0,0.30,TR,12.0,dummy.py,5,run2,label2\n"
+        "2026-06-13 12:00,func_c,3.0,0.40,TR,12.0,dummy.py,10,run3,label3\n"
+    )
+    
+    class Args:
+        file = str(csv_file)
+        before = "2026-06-12"
+        keep_runs = None
+        
+    from ecotrace.cli import _cmd_clean
+    _cmd_clean(Args())
+    captured = capsys.readouterr()
+    assert "Trimmed 1 entries" in captured.out
+    assert os.path.exists(str(csv_file) + ".bak")
+    
+    # Read output and verify first entry is deleted
+    content = csv_file.read_text()
+    assert "func_a" not in content
+    assert "func_b" in content
+    assert "func_c" in content
+
+def test_cli_reset_success(tmp_path, capsys):
+    csv_file = tmp_path / "reset_test_log.csv"
+    csv_file.write_text("dummy content")
+    
+    class Args:
+        file = str(csv_file)
+        yes = True
+        
+    from ecotrace.cli import _cmd_reset
+    _cmd_reset(Args())
+    assert not os.path.exists(csv_file)
+
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -86,3 +86,34 @@ def test_csv_logging_does_not_crash_on_error(ecotrace_instance):
     with patch("builtins.open", side_effect=OSError("Permission denied")):
         # This should log a warning but not raise an exception
         ecotrace_instance._log_to_csv("test_func", 1.0, 0.01)
+
+def test_pause_resume(ecotrace_instance):
+    assert not ecotrace_instance._paused
+    ecotrace_instance.pause()
+    assert ecotrace_instance._paused
+    
+    # Test that _accumulate_carbon returns immediately when paused
+    initial_carbon = ecotrace_instance.total_carbon
+    ecotrace_instance._accumulate_carbon(0.5, "paused_func", 1.0)
+    assert ecotrace_instance.total_carbon == initial_carbon
+    
+    ecotrace_instance.resume()
+    assert not ecotrace_instance._paused
+    
+    ecotrace_instance._accumulate_carbon(0.5, "resumed_func", 1.0)
+    assert ecotrace_instance.total_carbon == initial_carbon + 0.5
+
+def test_async_measure_hotspot_metadata(ecotrace_instance):
+    import asyncio
+    async def async_dummy():
+        return 42
+        
+    with patch.object(ecotrace_instance, "_log_to_csv") as mock_log:
+        asyncio.run(ecotrace_instance.measure_async(async_dummy))
+        mock_log.assert_called_once()
+        args, kwargs = mock_log.call_args
+        assert args[0] == "async_dummy"
+        assert args[4] is not None
+        assert args[4].endswith("test_core.py")
+        assert args[5] is not None
+

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -14,6 +14,27 @@ def test_add_exporter_core_api():
     assert len(eco._exporters) == 1
     assert eco._exporters[0] is mock_exporter
 
+
+def test_accumulate_carbon_falls_back_to_sync_export_when_thread_pool_submit_fails():
+    """Exporter dispatch should still work if the background pool cannot accept work."""
+    eco = EcoTrace(quiet=True, check_updates=False)
+    exporter = MagicMock()
+    eco.add_exporter(exporter)
+
+    with patch.object(eco._exporter_pool, "submit", side_effect=RuntimeError("pool closed")):
+        eco._accumulate_carbon(
+            carbon_emitted=0.005,
+            func_name="test_function",
+            duration=1.2,
+        )
+
+    exporter.export.assert_called_once_with(
+        carbon_emitted=0.005,
+        func_name="test_function",
+        duration=1.2,
+        region=eco.region_code,
+    )
+
 @patch('ecotrace.exporters.otel.metrics')
 def test_otel_exporter_registration_and_export(mock_metrics):
     """Verify OTelExporter attaches to EcoTrace and exports metrics successfully."""
@@ -69,3 +90,51 @@ def test_otel_exporter_missing_dependency():
         exporter.export(0.5, "test", 1.0, "GLOBAL")
 
 # /* --- Hybrid End of File / Dosya Sonu --- */ #
+
+from ecotrace.exporters.webhook import WebhookExporter
+
+@patch('requests.post')
+def test_webhook_exporter_registration_and_export(mock_post):
+    """Verify WebhookExporter attaches to EcoTrace and POSTs metrics successfully."""
+    mock_post.return_value.status_code = 200
+
+    eco = EcoTrace(quiet=True, check_updates=False)
+    eco._run_id = "test_run_id"
+    eco._run_label = "test_label"
+    
+    exporter = WebhookExporter(ecotrace_instance=eco, url="http://example.com/webhook", headers={"X-Test": "Value"})
+    
+    assert len(eco._exporters) == 1
+    assert eco._exporters[0] is exporter
+    
+    eco.region_code = "US"
+    eco._accumulate_carbon(
+        carbon_emitted=0.005,
+        func_name="test_function",
+        duration=1.2
+    )
+    
+    eco._exporter_pool.shutdown(wait=True)
+    
+    # Assert requests.post was called with the correct args
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    assert args[0] == "http://example.com/webhook"
+    assert kwargs["headers"] == {"Content-Type": "application/json", "X-Test": "Value"}
+    payload = kwargs["json"]
+    assert payload["function"] == "test_function"
+    assert payload["carbon_gco2"] == 0.005
+    assert payload["duration_s"] == 1.2
+    assert payload["region"] == "US"
+    assert payload["run_id"] == "test_run_id"
+    assert payload["run_label"] == "test_label"
+
+def test_webhook_exporter_missing_dependency():
+    """Verify WebhookExporter handles missing requests gracefully."""
+    eco = EcoTrace(quiet=True, check_updates=False)
+    
+    with patch('ecotrace.exporters.webhook.requests', None):
+        exporter = WebhookExporter(ecotrace_instance=eco, url="http://example.com")
+        assert exporter.url is None
+        exporter.export(0.5, "test", 1.0, "GLOBAL")
+

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -6,15 +6,15 @@ from ecotrace.gpu import get_gpu_info
 from ecotrace.ram import get_ram_info
 
 def test_cpu_info_detection():
-    # We mock cpuinfo to return a predictable string
-    with patch("ecotrace.cpu.cpuinfo.get_cpu_info", return_value={"brand_raw": "Intel Core i9-13900K"}):
+    # We mock fetch_raw_cpu_info to return a predictable string
+    with patch("ecotrace.cpu.fetch_raw_cpu_info", return_value={"brand_raw": "Intel Core i9-13900K"}):
         info = get_cpu_info({}, {})
         assert "Intel Core i9" in info["brand"]
         assert info["cores"] > 0
         assert info["tdp"] == 65.0  # Fallback TDP if not in DB
 
 def test_apple_silicon_tdp():
-    with patch("ecotrace.cpu.cpuinfo.get_cpu_info", return_value={"brand_raw": "Apple M2 Max"}):
+    with patch("ecotrace.cpu.fetch_raw_cpu_info", return_value={"brand_raw": "Apple M2 Max"}):
         constants = {"TDP_MAP": {"M2": 30.0}}
         info = get_cpu_info({}, constants)
         assert info["tdp"] == 30.0


### PR DESCRIPTION
## EcoTrace v1.4.0

### Added
- **\ecotrace diff\**: Side-by-side carbon footprint comparison of any two runs
- **CSV Export**: Extended \ecotrace export\ with \--csv\ format and \--run\/\--func\ filters
- **Pausing API**: \EcoTrace.pause()\ and \EcoTrace.resume()\ for temporarily disabling tracking
- **\WebhookExporter\**: Push carbon metrics to webhooks in real-time (Slack, Teams, Discord, custom API)
- **\ecotrace clean\**: Rotate/cleanup log CSV by run count or date, with automatic backup
- **\ecotrace reset\**: Reset/delete CSV log file completely with verification

### Fixed
- **Duplicate Carbon Calculations**: Fixed duplicate carbon calculation in Keras and PyTorch callbacks
- **Empty GPU monitoring crash**: Guarded \EcoTraceML\ shutdown against empty GPU monitor histories
- **Async Metadata propagation**: Propagated source file paths and line numbers correctly in \measure_async()\
- **CPU Cache Optimization**: Reused cached CPU info query in \get_cpu_info\

### Infra
- Fixed CI workflow action versions: \checkout@v4\, \setup-python@v5\

### Test Results
- 81/81 tests passing on Python 3.11