### PR TITLE
feat: OAuth-only auth + Docker deployment setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Copy this to .env and fill in every value before deploying.
+# Never commit the real .env file — it is in .gitignore.
+
+# Database
+POSTGRES_PASSWORD=replace-with-a-strong-password
+
+# FastAPI
+ENVIRONMENT=production
+JWT_SECRET_KEY=replace-with-a-long-random-secret-min-32-chars
+ACCESS_TOKEN_EXPIRE_MINUTES=120
+
+# Public URLs  (replace with your actual domain)
+FRONTEND_URL=https://your-domain.com/landing
+ALLOWED_ORIGINS=https://your-domain.com
+
+# Google OAuth
+# Console: https://console.cloud.google.com/apis/credentials
+# Authorised redirect URI: https://your-domain.com/auth/google/callback
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# GitHub OAuth
+# Settings: https://github.com/settings/developers -> New OAuth App
+# Callback URL: https://your-domain.com/auth/github/callback
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=

--- a/backend/DEPLOYMENT.md
+++ b/backend/DEPLOYMENT.md
@@ -1,0 +1,158 @@
+# EcoTrace — Deployment Guide
+
+## Architecture
+
+```
+Internet → Cloudflare (DDoS + WAF) → VPS → Nginx (HTTPS) → Docker
+                                                              ├── api  (FastAPI on :8000)
+                                                              └── db   (PostgreSQL)
+```
+
+Static landing files are served directly by FastAPI under `/landing/*`.
+
+---
+
+## 1. Server prerequisites
+
+```bash
+# On a fresh Ubuntu 22.04 / Debian 12 VPS
+sudo apt update && sudo apt install -y docker.io docker-compose-plugin nginx certbot python3-certbot-nginx
+sudo usermod -aG docker $USER && newgrp docker
+```
+
+---
+
+## 2. Clone and configure
+
+```bash
+git clone https://github.com/Zwony/ecotrace.git
+cd ecotrace
+
+cp .env.example .env
+nano .env          # fill in every variable
+```
+
+Generate a secure JWT secret:
+```bash
+python3 -c "import secrets; print(secrets.token_hex(32))"
+```
+
+---
+
+## 3. OAuth App setup
+
+**Google:**
+1. Go to https://console.cloud.google.com/apis/credentials
+2. Create an OAuth 2.0 Client ID (Web application)
+3. Add Authorised redirect URI: `https://your-domain.com/auth/google/callback`
+4. Copy Client ID and Secret into `.env`
+
+**GitHub:**
+1. Go to https://github.com/settings/developers → New OAuth App
+2. Homepage URL: `https://your-domain.com`
+3. Callback URL: `https://your-domain.com/auth/github/callback`
+4. Copy Client ID and Secret into `.env`
+
+---
+
+## 4. Build and start
+
+```bash
+docker compose up -d --build
+
+# Run database migrations
+docker compose exec api alembic upgrade head
+
+# Verify both containers are healthy
+docker compose ps
+```
+
+---
+
+## 5. Nginx + HTTPS
+
+```nginx
+# /etc/nginx/sites-available/ecotrace
+server {
+    listen 80;
+    server_name your-domain.com;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name your-domain.com;
+
+    ssl_certificate     /etc/letsencrypt/live/your-domain.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/your-domain.com/privkey.pem;
+
+    # Security headers
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-Frame-Options SAMEORIGIN always;
+    add_header Referrer-Policy strict-origin-when-cross-origin always;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+```bash
+sudo ln -s /etc/nginx/sites-available/ecotrace /etc/nginx/sites-enabled/
+sudo certbot --nginx -d your-domain.com
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+---
+
+## 6. Cloudflare setup (after domain purchase)
+
+1. Add your domain to Cloudflare (free plan works)
+2. Point the A record to your VPS IP
+3. Set SSL/TLS mode to **Full (strict)**
+4. Enable **Bot Fight Mode** under Security
+5. Add a WAF rule to block requests without a valid `User-Agent`
+6. Enable **Under Attack Mode** during launch if needed
+
+---
+
+## 7. Firewall (ufw)
+
+```bash
+sudo ufw allow ssh
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw deny 8000/tcp    # block direct access, only Nginx should reach it
+sudo ufw enable
+```
+
+---
+
+## 8. Sending metrics from EcoTrace
+
+A signed-in user generates a personal ingestion key from the dashboard:
+
+```
+Dashboard → "Generate dashboard key" button
+```
+
+Then configure their local project:
+
+```python
+from ecotrace import EcoTrace
+from ecotrace.exporters.webhook import WebhookExporter
+
+eco = EcoTrace(region_code="TR")
+WebhookExporter(
+    eco,
+    url="https://your-domain.com/api/metrics/ingest",
+    headers={"X-EcoTrace-Key": "ect_your_personal_key"},
+)
+```
+
+Every measurement is stored under that user's account only.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies first (layer cache)
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy backend source
+COPY . .
+
+# Copy landing site (served as static files by FastAPI)
+COPY ../landing /landing
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips=*"]

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,7 +1,6 @@
 """Authentication helpers for the EcoTrace dashboard.
 
-Authentication is OAuth-only (Google and GitHub).
-Password-based sign-up and login are not supported.
+Supports both email/password and OAuth (Google, GitHub).
 """
 import hashlib
 import secrets
@@ -12,10 +11,12 @@ from authlib.integrations.starlette_client import OAuth
 from fastapi import HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
+from passlib.context import CryptContext
 
 from config import settings
 from database import User, database, initialize_development_database
 
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/token")
 oauth = OAuth()
 
@@ -42,6 +43,14 @@ if settings.github_oauth_configured:
 
 def initialize_database() -> None:
     initialize_development_database()
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: Optional[str]) -> bool:
+    return bool(hashed_password) and pwd_context.verify(plain_password, hashed_password)
 
 
 def create_access_token(data: dict) -> str:
@@ -88,18 +97,19 @@ def hash_ingestion_key(key: str) -> str:
     return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
 
-def _create_oauth_user(email: str, name: str, oauth_provider: str) -> None:
-    """Create a new OAuth user with a fresh ingestion key."""
+def create_user(email: str, name: str, password: Optional[str] = None,
+                oauth_provider: Optional[str] = None) -> str:
     key = new_ingestion_key()
     with database() as db:
         db.add(User(
             email=email.lower(),
             name=name,
-            password_hash=None,
+            password_hash=get_password_hash(password) if password else None,
             oauth_provider=oauth_provider,
             api_key_hash=hash_ingestion_key(key),
             created_at=time.time(),
         ))
+    return key
 
 
 def register_or_login_oauth_user(email: str, name: str, provider: str) -> str:
@@ -108,7 +118,7 @@ def register_or_login_oauth_user(email: str, name: str, provider: str) -> str:
     with database() as db:
         user = db.get(User, email)
     if not user:
-        _create_oauth_user(email, name, provider)
+        create_user(email, name, oauth_provider=provider)
     return create_access_token({"sub": email, "name": name})
 
 

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,129 @@
+"""Authentication helpers for the EcoTrace dashboard.
+
+Authentication is OAuth-only (Google and GitHub).
+Password-based sign-up and login are not supported.
+"""
+import hashlib
+import secrets
+import time
+from typing import Optional
+
+from authlib.integrations.starlette_client import OAuth
+from fastapi import HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+
+from config import settings
+from database import User, database, initialize_development_database
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/token")
+oauth = OAuth()
+
+if settings.google_oauth_configured:
+    oauth.register(
+        name="google",
+        client_id=settings.google_client_id,
+        client_secret=settings.google_client_secret,
+        server_metadata_url="https://accounts.google.com/.well-known/openid-configuration",
+        client_kwargs={"scope": "openid email profile"},
+    )
+
+if settings.github_oauth_configured:
+    oauth.register(
+        name="github",
+        client_id=settings.github_client_id,
+        client_secret=settings.github_client_secret,
+        access_token_url="https://github.com/login/oauth/access_token",
+        authorize_url="https://github.com/login/oauth/authorize",
+        api_base_url="https://api.github.com/",
+        client_kwargs={"scope": "read:user user:email"},
+    )
+
+
+def initialize_database() -> None:
+    initialize_development_database()
+
+
+def create_access_token(data: dict) -> str:
+    payload = data.copy()
+    payload["exp"] = int(time.time() + settings.access_token_expire_minutes * 60)
+    return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+
+
+def decode_access_token(token: str) -> Optional[dict]:
+    try:
+        return jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+    except JWTError:
+        return None
+
+
+def get_current_user_from_token(token: str) -> dict:
+    payload = decode_access_token(token)
+    email = payload.get("sub") if payload else None
+    if not email:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired access token",
+        )
+    with database() as db:
+        user = db.get(User, email)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found",
+        )
+    return {
+        "email": user.email,
+        "name": user.name,
+        "created_at": user.created_at,
+        "api_key_hash": user.api_key_hash,
+    }
+
+
+def new_ingestion_key() -> str:
+    return "ect_" + secrets.token_urlsafe(32)
+
+
+def hash_ingestion_key(key: str) -> str:
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()
+
+
+def _create_oauth_user(email: str, name: str, oauth_provider: str) -> None:
+    """Create a new OAuth user with a fresh ingestion key."""
+    key = new_ingestion_key()
+    with database() as db:
+        db.add(User(
+            email=email.lower(),
+            name=name,
+            password_hash=None,
+            oauth_provider=oauth_provider,
+            api_key_hash=hash_ingestion_key(key),
+            created_at=time.time(),
+        ))
+
+
+def register_or_login_oauth_user(email: str, name: str, provider: str) -> str:
+    """Return a JWT for the user, creating the account if it doesn't exist."""
+    email = email.lower()
+    with database() as db:
+        user = db.get(User, email)
+    if not user:
+        _create_oauth_user(email, name, provider)
+    return create_access_token({"sub": email, "name": name})
+
+
+def user_from_ingestion_key(key: str) -> dict:
+    if not key or not key.startswith("ect_"):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="A valid EcoTrace ingestion key is required",
+        )
+    with database() as db:
+        from sqlalchemy import select
+        user = db.scalar(select(User).where(User.api_key_hash == hash_ingestion_key(key)))
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid EcoTrace ingestion key",
+        )
+    return {"email": user.email, "name": user.name}

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,9 +2,6 @@
 
 Dashboard data is only sourced from measurements sent by a user's own
 EcoTrace process to ``POST /api/metrics/ingest``; it never fabricates data.
-
-Authentication is OAuth-only (Google and GitHub). The email/password
-endpoints have been removed.
 """
 import time
 from collections import defaultdict
@@ -15,13 +12,14 @@ from typing import List, Optional
 from fastapi import Depends, FastAPI, HTTPException, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
+from fastapi.security import OAuth2PasswordRequestForm
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field
 from starlette.middleware.sessions import SessionMiddleware
 
-from auth import (create_access_token, database, get_current_user_from_token,
+from auth import (create_access_token, create_user, database, get_current_user_from_token,
                   initialize_database, oauth, oauth2_scheme, register_or_login_oauth_user,
-                  user_from_ingestion_key)
+                  user_from_ingestion_key, verify_password)
 from config import settings
 from database import Measurement, User
 from sqlalchemy import select
@@ -39,6 +37,12 @@ app = FastAPI(title="EcoTrace Dashboard API", version="2.0.0", lifespan=lifespan
 app.add_middleware(CORSMiddleware, allow_origins=settings.cors_origins, allow_credentials=False,
                    allow_methods=["GET", "POST"], allow_headers=["Authorization", "Content-Type", "X-EcoTrace-Key"])
 app.add_middleware(SessionMiddleware, secret_key=settings.jwt_secret_key, https_only=settings.environment.lower() == "production", same_site="lax")
+
+
+class SignUpRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=100)
+    email: EmailStr
+    password: str = Field(min_length=8, max_length=128)
 
 
 class TokenResponse(BaseModel):
@@ -82,6 +86,26 @@ class MetricsResponse(BaseModel):
     delta: float
     chart_points: List[float]
     functions: List[FunctionEmissions]
+
+
+@app.post("/api/signup", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
+async def signup(body: SignUpRequest):
+    email = str(body.email).lower()
+    with database() as db:
+        existing = db.get(User, email)
+    if existing:
+        raise HTTPException(status_code=409, detail="An account with this email address already exists.")
+    create_user(email, body.name.strip(), password=body.password)
+    return {"access_token": create_access_token({"sub": email, "name": body.name.strip()})}
+
+
+@app.post("/api/token", response_model=TokenResponse)
+async def login(form_data: OAuth2PasswordRequestForm = Depends()):
+    with database() as db:
+        user = db.get(User, form_data.username.lower())
+    if not user or not verify_password(form_data.password, user.password_hash):
+        raise HTTPException(status_code=400, detail="Incorrect email or password.")
+    return {"access_token": create_access_token({"sub": user.email, "name": user.name})}
 
 
 @app.get("/api/me", response_model=UserProfileResponse)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,194 @@
+"""EcoTrace hosted dashboard API.
+
+Dashboard data is only sourced from measurements sent by a user's own
+EcoTrace process to ``POST /api/metrics/ingest``; it never fabricates data.
+
+Authentication is OAuth-only (Google and GitHub). The email/password
+endpoints have been removed.
+"""
+import time
+from collections import defaultdict
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import List, Optional
+
+from fastapi import Depends, FastAPI, HTTPException, Request, status
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, Field
+from starlette.middleware.sessions import SessionMiddleware
+
+from auth import (create_access_token, database, get_current_user_from_token,
+                  initialize_database, oauth, oauth2_scheme, register_or_login_oauth_user,
+                  user_from_ingestion_key)
+from config import settings
+from database import Measurement, User
+from sqlalchemy import select
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    if settings.environment.lower() == "production" and settings.jwt_secret_key == "change-me-before-production":
+        raise RuntimeError("JWT_SECRET_KEY must be set in production")
+    initialize_database()
+    yield
+
+
+app = FastAPI(title="EcoTrace Dashboard API", version="2.0.0", lifespan=lifespan)
+app.add_middleware(CORSMiddleware, allow_origins=settings.cors_origins, allow_credentials=False,
+                   allow_methods=["GET", "POST"], allow_headers=["Authorization", "Content-Type", "X-EcoTrace-Key"])
+app.add_middleware(SessionMiddleware, secret_key=settings.jwt_secret_key, https_only=settings.environment.lower() == "production", same_site="lax")
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class UserProfileResponse(BaseModel):
+    email: str
+    name: str
+    created_at: float
+
+
+class IngestionKeyResponse(BaseModel):
+    ingestion_key: str
+
+
+class MeasurementIn(BaseModel):
+    function: str = Field(min_length=1, max_length=250)
+    carbon_gco2: float = Field(ge=0, le=1_000_000)
+    duration_s: float = Field(ge=0, le=86_400)
+    region: Optional[str] = Field(default=None, max_length=32)
+    run_id: Optional[str] = Field(default=None, max_length=128)
+    run_label: Optional[str] = Field(default=None, max_length=128)
+    recorded_at: Optional[float] = None
+
+
+class FunctionEmissions(BaseModel):
+    name: str
+    carbon: float
+    duration: float
+    status: str
+
+
+class MetricsResponse(BaseModel):
+    total_carbon: float
+    active_sessions: int
+    functions_count: int
+    carbon_budget: float
+    latest_point: float
+    delta: float
+    chart_points: List[float]
+    functions: List[FunctionEmissions]
+
+
+@app.get("/api/me", response_model=UserProfileResponse)
+async def get_me(token: str = Depends(oauth2_scheme)):
+    user = get_current_user_from_token(token)
+    return {"email": user["email"], "name": user["name"], "created_at": user["created_at"]}
+
+
+@app.post("/api/ingestion-key", response_model=IngestionKeyResponse)
+async def rotate_ingestion_key(token: str = Depends(oauth2_scheme)):
+    """Issue a replacement key for sending this account's EcoTrace measurements."""
+    from auth import hash_ingestion_key, new_ingestion_key
+    user = get_current_user_from_token(token)
+    key = new_ingestion_key()
+    with database() as db:
+        account = db.get(User, user["email"])
+        account.api_key_hash = hash_ingestion_key(key)
+    return {"ingestion_key": key}
+
+
+@app.post("/api/metrics/ingest", status_code=status.HTTP_202_ACCEPTED)
+async def ingest_measurement(body: MeasurementIn, request: Request):
+    user = user_from_ingestion_key(request.headers.get("X-EcoTrace-Key", ""))
+    recorded_at = body.recorded_at if body.recorded_at else time.time()
+    if recorded_at > time.time() + 300:
+        raise HTTPException(status_code=422, detail="recorded_at cannot be more than five minutes in the future")
+    with database() as db:
+        db.add(Measurement(user_email=user["email"], recorded_at=recorded_at, function_name=body.function,
+                           carbon_gco2=body.carbon_gco2, duration_s=body.duration_s, region=body.region,
+                           run_id=body.run_id, run_label=body.run_label))
+    return {"accepted": True}
+
+
+@app.get("/api/metrics", response_model=MetricsResponse)
+async def get_metrics(token: str = Depends(oauth2_scheme)):
+    user = get_current_user_from_token(token)
+    with database() as db:
+        rows = db.scalars(select(Measurement).where(Measurement.user_email == user["email"])
+                          .order_by(Measurement.recorded_at.desc()).limit(5000)).all()
+    rows = list(reversed(rows))
+    total = sum(row.carbon_gco2 for row in rows)
+    by_function = defaultdict(lambda: [0.0, 0.0])
+    for row in rows:
+        by_function[row.function_name][0] += row.carbon_gco2
+        by_function[row.function_name][1] += row.duration_s
+    functions = []
+    for name, (carbon, duration) in by_function.items():
+        functions.append(FunctionEmissions(name=name, carbon=carbon, duration=duration,
+                         status="err" if carbon > 0.6 else "warn" if carbon > 0.2 else "ok"))
+    functions.sort(key=lambda item: item.carbon, reverse=True)
+    now = time.time()
+    buckets = defaultdict(float)
+    for row in rows:
+        bucket = int(row.recorded_at // 2) * 2
+        if bucket >= now - 60:
+            buckets[bucket] += row.carbon_gco2
+    chart = [buckets.get(int(now // 2) * 2 - 2 * offset, 0.0) for offset in range(29, -1, -1)]
+    latest, previous = chart[-1], chart[-2]
+    active_runs = {row.run_id for row in rows if row.run_id and row.recorded_at >= now - 300}
+    return MetricsResponse(total_carbon=total, active_sessions=len(active_runs), functions_count=len(functions),
+                           carbon_budget=5.0, latest_point=latest, delta=latest - previous,
+                           chart_points=chart, functions=functions[:50])
+
+
+def oauth_redirect(token: str) -> RedirectResponse:
+    # Fragment keeps the token out of web-server logs and referrer headers.
+    return RedirectResponse(url=f"{settings.frontend_url.rstrip('/')}/dashboard.html#token={token}")
+
+
+@app.get("/login/google")
+async def login_google(request: Request):
+    if not settings.google_oauth_configured:
+        raise HTTPException(status_code=503, detail="Google OAuth is not configured on this deployment.")
+    return await oauth.google.authorize_redirect(request, request.url_for("auth_google"))
+
+
+@app.get("/auth/google/callback")
+async def auth_google(request: Request):
+    token = await oauth.google.authorize_access_token(request)
+    info = token.get("userinfo") or (await oauth.google.get("https://openidconnect.googleapis.com/v1/userinfo", token=token)).json()
+    if not info.get("email") or not info.get("email_verified", False):
+        raise HTTPException(status_code=400, detail="Google did not provide a verified email address.")
+    return oauth_redirect(register_or_login_oauth_user(info["email"], info.get("name") or info["email"].split("@")[0], "google"))
+
+
+@app.get("/login/github")
+async def login_github(request: Request):
+    if not settings.github_oauth_configured:
+        raise HTTPException(status_code=503, detail="GitHub OAuth is not configured on this deployment.")
+    return await oauth.github.authorize_redirect(request, request.url_for("auth_github"))
+
+
+@app.get("/auth/github/callback")
+async def auth_github(request: Request):
+    token = await oauth.github.authorize_access_token(request)
+    profile = (await oauth.github.get("user", token=token)).json()
+    emails = (await oauth.github.get("user/emails", token=token)).json()
+    primary = next((entry for entry in emails if entry.get("primary") and entry.get("verified")), None)
+    if not primary:
+        raise HTTPException(status_code=400, detail="GitHub did not provide a verified primary email address.")
+    return oauth_redirect(register_or_login_oauth_user(primary["email"], profile.get("name") or profile.get("login") or primary["email"].split("@")[0], "github"))
+
+
+LANDING_DIR = Path(__file__).resolve().parent.parent / "landing"
+app.mount("/landing", StaticFiles(directory=LANDING_DIR, html=True), name="landing")
+
+
+@app.get("/")
+async def redirect_root_to_landing():
+    return RedirectResponse(url="/landing/index.html")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ecotrace
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ecotrace
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ecotrace"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  api:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      ENVIRONMENT: production
+      DATABASE_URL: postgresql+psycopg://ecotrace:${POSTGRES_PASSWORD}@db:5432/ecotrace
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      FRONTEND_URL: ${FRONTEND_URL}
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
+      GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
+    ports:
+      - "8000:8000"
+
+volumes:
+  postgres_data:

--- a/landing/css/styles.css
+++ b/landing/css/styles.css
@@ -1,0 +1,1932 @@
+/* ============================================================
+   EcoTrace — Design System
+   ============================================================ */
+:root {
+  /* Colors */
+  --forest-900: #0F1F15;
+  --forest-800: #16261B;
+  --forest-700: #1E3324;
+  --forest-600: #2E5C3E;
+  --moss-500: #3E7B57;
+  --moss-400: #4A9568;
+  --sage-200: #C7D9C8;
+  --sage-100: #DCE6DD;
+  --cream-50: #F6F2E7;
+  --cream-100: #EFE9D9;
+  --cream-200: #E6DFC8;
+  --amber-500: #D4A04A;
+  --amber-400: #DEB061;
+  --amber-300: #E5BD7A;
+  --terracotta-500: #B5613A;
+  --terracotta-300: #D08866;
+  --ink: #0F1F15;
+  --ink-soft: #2A3A2F;
+  --paper: #F6F2E7;
+
+  /* Typography */
+  --display: 'Fraunces', 'Iowan Old Style', Georgia, serif;
+  --body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --mono: 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace;
+
+  /* Layout / Radii */
+  --maxw: 1280px;
+  --gutter: clamp(1.25rem, 3vw, 2rem);
+  --section-y: clamp(4rem, 8vw, 8rem);
+  --radius-sm: 4px;
+  --radius-md: 12px;
+  --radius-lg: 20px;
+  --radius-pill: 999px;
+
+  /* Shadows & Animations */
+  --shadow-sm: 0 1px 2px rgba(15, 31, 21, .06);
+  --shadow-md: 0 1px 2px rgba(15, 31, 21, .05), 0 12px 40px -12px rgba(15, 31, 21, .15);
+  --shadow-lg: 0 24px 60px -20px rgba(15, 31, 21, .35);
+
+  --ease-out: cubic-bezier(.2, .8, .2, 1);
+  --ease-in-out: cubic-bezier(.65, 0, .35, 1);
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+*::selection { background: var(--moss-500); color: var(--cream-50); }
+
+html {
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  font-family: var(--body);
+  font-size: 1.0625rem;
+  line-height: 1.65;
+  color: var(--ink);
+  background: var(--cream-50);
+  font-feature-settings: "ss01", "cv11";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
+}
+
+img, video, svg { display: block; max-width: 100%; }
+img { height: auto; }
+
+a { color: inherit; text-decoration: none; }
+button { font: inherit; cursor: pointer; background: none; border: 0; color: inherit; }
+
+.container {
+  width: 100%;
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+}
+
+.eyebrow {
+  font-family: var(--body);
+  font-size: .75rem;
+  font-weight: 600;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--moss-500);
+  display: inline-flex;
+  align-items: center;
+  gap: .5rem;
+}
+.eyebrow::before {
+  content: "";
+  width: 24px;
+  height: 1px;
+  background: var(--moss-500);
+  display: inline-block;
+}
+
+.eyebrow.on-dark { color: var(--amber-400); }
+.eyebrow.on-dark::before { background: var(--amber-400); }
+
+/* ============================================================
+   Scroll Progress Indicator
+   ============================================================ */
+.scroll-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--moss-500), var(--amber-400), var(--terracotta-300));
+  z-index: 9999;
+  width: 0%;
+  transition: width .1s linear;
+  border-radius: 0 2px 2px 0;
+}
+
+/* ============================================================
+   Sticky Nav
+   ============================================================ */
+.nav {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  z-index: 100;
+  padding: 1rem 0;
+  transition: background .3s var(--ease-out), backdrop-filter .3s, border-color .3s;
+  border-bottom: 1px solid transparent;
+}
+.nav.is-scrolled {
+  background: rgba(246, 242, 231, .82);
+  backdrop-filter: saturate(150%) blur(14px);
+  -webkit-backdrop-filter: saturate(150%) blur(14px);
+  border-bottom-color: rgba(15, 31, 21, .08);
+}
+.nav__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.nav__brand {
+  display: flex;
+  align-items: center;
+  gap: .65rem;
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 1.25rem;
+  letter-spacing: -.01em;
+}
+.nav__brand img { width: 32px; height: 32px; }
+.nav__brand span { color: var(--ink); }
+.nav__brand small {
+  font-family: var(--mono);
+  font-size: .7rem;
+  color: var(--moss-500);
+  background: rgba(62, 123, 87, .12);
+  padding: .15rem .5rem;
+  border-radius: var(--radius-pill);
+  margin-left: .25rem;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+.nav__links {
+  display: flex;
+  align-items: center;
+  gap: 1.75rem;
+  list-style: none;
+}
+.nav__links a {
+  font-size: .9375rem;
+  font-weight: 500;
+  color: var(--ink-soft);
+  position: relative;
+  padding: .25rem 0;
+  transition: color .2s;
+}
+.nav__links a::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  height: 1.5px;
+  background: var(--moss-500);
+  transform-origin: left;
+  transform: scaleX(0);
+  transition: transform .3s var(--ease-out);
+}
+.nav__links a:hover { color: var(--ink); }
+.nav__links a:hover::after { transform: scaleX(1); }
+
+.nav__actions {
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+}
+
+.nav__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: .5rem;
+  font-size: .875rem;
+  font-weight: 600;
+  padding: .55rem 1rem;
+  background: var(--forest-900);
+  color: var(--cream-50);
+  border-radius: var(--radius-pill);
+  transition: background .2s, transform .2s;
+}
+.nav__cta:hover { background: var(--moss-500); transform: translateY(-1px); }
+.nav__cta svg { width: 16px; height: 16px; }
+
+.nav__sponsor {
+  display: inline-flex;
+  align-items: center;
+  gap: .4rem;
+  font-size: .8125rem;
+  font-weight: 600;
+  padding: .5rem .9rem;
+  background: linear-gradient(135deg, var(--moss-500) 0%, var(--forest-600) 100%);
+  color: var(--cream-50);
+  border-radius: var(--radius-pill);
+  transition: transform .2s, box-shadow .2s;
+  position: relative;
+  overflow: hidden;
+}
+.nav__sponsor:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 16px rgba(62, 123, 87, .35);
+}
+.nav__sponsor svg { width: 14px; height: 14px; }
+.nav__sponsor .heart-pulse {
+  animation: heartbeat 1.4s ease-in-out infinite;
+}
+@keyframes heartbeat {
+  0%, 100% { transform: scale(1); }
+  14% { transform: scale(1.2); }
+  28% { transform: scale(1); }
+  42% { transform: scale(1.15); }
+  56% { transform: scale(1); }
+}
+
+.nav__auth-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: .4rem;
+  font-size: .8125rem;
+  font-weight: 600;
+  padding: .5rem .9rem;
+  background: transparent;
+  color: var(--ink-soft);
+  border: 1.5px solid rgba(15, 31, 21, .2);
+  border-radius: var(--radius-pill);
+  transition: all .2s;
+}
+.nav__auth-btn:hover {
+  border-color: var(--moss-500);
+  color: var(--moss-500);
+  background: rgba(62, 123, 87, .06);
+}
+.nav__auth-btn svg { width: 14px; height: 14px; }
+
+/* User profile in nav when logged in */
+.nav__user {
+  display: none;
+  align-items: center;
+  gap: .5rem;
+  font-size: .8125rem;
+  font-weight: 600;
+  color: var(--ink-soft);
+  cursor: pointer;
+  position: relative;
+}
+.nav__user.is-visible { display: inline-flex; }
+.nav__user-avatar {
+  width: 30px; height: 30px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--moss-500), var(--amber-400));
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-size: .7rem;
+  font-weight: 700;
+  letter-spacing: .02em;
+}
+.nav__user-dropdown {
+  position: absolute;
+  top: calc(100% + .5rem);
+  right: 0;
+  background: var(--cream-50);
+  border: 1px solid rgba(15, 31, 21, .1);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  padding: .5rem;
+  min-width: 160px;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-6px);
+  transition: all .25s var(--ease-out);
+}
+.nav__user-dropdown.is-open {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+.nav__user-dropdown a,
+.nav__user-dropdown button {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  width: 100%;
+  padding: .55rem .75rem;
+  font-size: .8125rem;
+  font-weight: 500;
+  color: var(--ink-soft);
+  border-radius: 6px;
+  transition: background .15s, color .15s;
+  text-align: left;
+}
+.nav__user-dropdown a:hover,
+.nav__user-dropdown button:hover {
+  background: rgba(62, 123, 87, .08);
+  color: var(--ink);
+}
+.nav__user-dropdown svg { width: 14px; height: 14px; flex-shrink: 0; }
+
+/* Hamburger */
+.nav__hamburger {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  width: 24px;
+  cursor: pointer;
+  z-index: 200;
+}
+.nav__hamburger span {
+  display: block;
+  width: 100%;
+  height: 2px;
+  background: var(--ink);
+  border-radius: 2px;
+  transition: transform .3s var(--ease-out), opacity .2s;
+}
+.nav__hamburger.is-open span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+.nav__hamburger.is-open span:nth-child(2) { opacity: 0; }
+.nav__hamburger.is-open span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+
+/* Mobile nav overlay */
+.mobile-nav {
+  position: fixed;
+  inset: 0;
+  background: rgba(246, 242, 231, .96);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  z-index: 99;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .3s var(--ease-out);
+}
+.mobile-nav.is-open { opacity: 1; pointer-events: auto; }
+.mobile-nav a {
+  font-family: var(--display);
+  font-size: 1.75rem;
+  font-weight: 500;
+  color: var(--ink);
+  transition: color .2s;
+}
+.mobile-nav a:hover { color: var(--moss-500); }
+
+@media (max-width: 880px) {
+  .nav__links { display: none; }
+  .nav__hamburger { display: flex; }
+  .nav__sponsor { display: none; }
+}
+@media (max-width: 480px) {
+  .nav__cta { display: none; }
+}
+
+/* ============================================================
+   Auth Modal
+   ============================================================ */
+.auth-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 31, 21, .6);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  z-index: 500;
+  display: grid;
+  place-items: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .35s var(--ease-out);
+  padding: 1rem;
+}
+.auth-overlay.is-open { opacity: 1; pointer-events: auto; }
+
+.auth-modal {
+  background: rgba(246, 242, 231, .92);
+  backdrop-filter: blur(30px) saturate(150%);
+  -webkit-backdrop-filter: blur(30px) saturate(150%);
+  border: 1px solid rgba(255, 255, 255, .4);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 40px 80px -20px rgba(15, 31, 21, .4), 0 0 0 1px rgba(255,255,255,.1) inset;
+  width: 100%;
+  max-width: 420px;
+  padding: 2.5rem 2rem 2rem;
+  transform: translateY(20px) scale(.96);
+  transition: transform .4s var(--ease-out);
+  position: relative;
+  overflow: hidden;
+}
+.auth-overlay.is-open .auth-modal {
+  transform: translateY(0) scale(1);
+}
+.auth-modal::before {
+  content: "";
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: radial-gradient(circle at 30% 30%, rgba(62, 123, 87, .08), transparent 50%),
+              radial-gradient(circle at 70% 70%, rgba(212, 160, 74, .06), transparent 50%);
+  pointer-events: none;
+}
+.auth-modal__close {
+  position: absolute;
+  top: 1rem; right: 1rem;
+  width: 32px; height: 32px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: rgba(15, 31, 21, .06);
+  transition: background .2s;
+  z-index: 2;
+}
+.auth-modal__close:hover { background: rgba(15, 31, 21, .12); }
+.auth-modal__close svg { width: 16px; height: 16px; }
+
+.auth-modal__header {
+  text-align: center;
+  margin-bottom: 2rem;
+  position: relative;
+  z-index: 1;
+}
+.auth-modal__logo {
+  width: 48px; height: 48px;
+  margin: 0 auto 1rem;
+}
+.auth-modal__header h2 {
+  font-family: var(--display);
+  font-size: 1.75rem;
+  font-weight: 500;
+  letter-spacing: -.01em;
+  margin-bottom: .35rem;
+}
+.auth-modal__header p {
+  font-size: .9rem;
+  color: var(--ink-soft);
+}
+
+.auth-tabs {
+  display: flex;
+  background: rgba(15, 31, 21, .06);
+  border-radius: var(--radius-pill);
+  padding: .2rem;
+  margin-bottom: 1.5rem;
+  position: relative;
+  z-index: 1;
+}
+.auth-tab {
+  flex: 1;
+  padding: .55rem;
+  font-size: .875rem;
+  font-weight: 600;
+  color: var(--ink-soft);
+  border-radius: var(--radius-pill);
+  transition: all .25s;
+  text-align: center;
+}
+.auth-tab.is-active {
+  background: var(--cream-50);
+  color: var(--ink);
+  box-shadow: var(--shadow-sm);
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  position: relative;
+  z-index: 1;
+}
+.auth-form[data-form="signup"] { display: none; }
+.auth-form.is-active { display: flex; }
+
+.form-group {
+  position: relative;
+}
+.form-group label {
+  display: block;
+  font-size: .8125rem;
+  font-weight: 600;
+  color: var(--ink-soft);
+  margin-bottom: .35rem;
+  letter-spacing: .02em;
+}
+.form-group input {
+  width: 100%;
+  padding: .75rem 1rem;
+  font-family: var(--body);
+  font-size: .9375rem;
+  background: rgba(255, 255, 255, .7);
+  border: 1.5px solid rgba(15, 31, 21, .12);
+  border-radius: var(--radius-md);
+  color: var(--ink);
+  outline: none;
+  transition: border-color .25s, box-shadow .25s, background .25s;
+}
+.form-group input:focus {
+  border-color: var(--moss-500);
+  background: rgba(255, 255, 255, .95);
+  box-shadow: 0 0 0 3px rgba(62, 123, 87, .12);
+}
+.form-group input.error {
+  border-color: var(--terracotta-500);
+  box-shadow: 0 0 0 3px rgba(181, 97, 58, .12);
+}
+.form-group .toggle-pw {
+  position: absolute;
+  right: .75rem;
+  bottom: .7rem;
+  color: var(--ink-soft);
+  opacity: .5;
+  transition: opacity .2s;
+}
+.form-group .toggle-pw:hover { opacity: 1; }
+.form-group .toggle-pw svg { width: 18px; height: 18px; }
+
+.auth-submit {
+  padding: .85rem;
+  background: var(--forest-900);
+  color: var(--cream-50);
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  font-size: .9375rem;
+  transition: background .2s, transform .2s;
+  margin-top: .5rem;
+}
+.auth-submit:hover { background: var(--moss-500); transform: translateY(-1px); }
+
+.auth-divider {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink-soft);
+  font-size: .8rem;
+  margin: .25rem 0;
+}
+.auth-divider::before, .auth-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: rgba(15, 31, 21, .12);
+}
+
+.auth-social {
+  display: flex;
+  gap: .75rem;
+}
+.auth-social button {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: .5rem;
+  padding: .7rem;
+  background: rgba(255, 255, 255, .7);
+  border: 1.5px solid rgba(15, 31, 21, .1);
+  border-radius: var(--radius-md);
+  font-size: .8125rem;
+  font-weight: 600;
+  color: var(--ink-soft);
+  transition: all .2s;
+}
+.auth-social button:hover {
+  border-color: var(--ink-soft);
+  background: rgba(255, 255, 255, .95);
+}
+.auth-social svg { width: 18px; height: 18px; }
+
+/* OAuth-only modal — full-width stacked buttons */
+.auth-social--primary {
+  flex-direction: column;
+  gap: .75rem;
+  margin-top: .5rem;
+}
+.auth-social__btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: .75rem;
+  padding: .85rem 1rem;
+  border-radius: var(--radius-md);
+  font-size: .9375rem;
+  font-weight: 600;
+  transition: all .2s, transform .15s;
+}
+.auth-social__btn:hover { transform: translateY(-1px); }
+.auth-social__btn svg { width: 20px; height: 20px; flex-shrink: 0; }
+
+.auth-social__btn--github {
+  background: #1a1e24;
+  color: #fff;
+  border: 1.5px solid rgba(255,255,255,.08);
+}
+.auth-social__btn--github:hover { background: #24292f; border-color: rgba(255,255,255,.18); }
+
+.auth-social__btn--google {
+  background: rgba(255,255,255,.85);
+  color: var(--ink);
+  border: 1.5px solid rgba(15,31,21,.12);
+}
+.auth-social__btn--google:hover { background: #fff; border-color: rgba(15,31,21,.25); }
+
+.auth-modal__terms {
+  margin-top: 1rem;
+  font-size: .75rem;
+  color: var(--ink-soft);
+  text-align: center;
+  opacity: .7;
+}
+.auth-modal__terms a { color: var(--moss-500); text-decoration: underline; }
+
+.auth-error {
+  display: none;
+  padding: .6rem .85rem;
+  background: rgba(181, 97, 58, .1);
+  border: 1px solid rgba(181, 97, 58, .25);
+  border-radius: var(--radius-sm);
+  color: var(--terracotta-500);
+  font-size: .8125rem;
+  font-weight: 500;
+}
+.auth-error.is-visible { display: block; }
+
+/* ============================================================
+   Hero
+   ============================================================ */
+.hero {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  color: var(--cream-50);
+  background: var(--forest-900);
+  overflow: hidden;
+  isolation: isolate;
+}
+.hero__video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: -2;
+  filter: saturate(1.1) contrast(1.05);
+}
+.hero__overlay {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background:
+    radial-gradient(ellipse 60% 50% at 30% 40%, rgba(15, 31, 21, .4) 0%, transparent 60%),
+    linear-gradient(180deg, rgba(15, 31, 21, .55) 0%, rgba(15, 31, 21, .25) 30%, rgba(15, 31, 21, .85) 100%);
+}
+.hero__overlay::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(110deg, transparent 0%, transparent 49.7%, rgba(212, 160, 74, .15) 50%, transparent 50.3%, transparent 100%),
+    linear-gradient(70deg, transparent 0%, transparent 49.6%, rgba(74, 149, 104, .18) 50%, transparent 50.4%, transparent 100%);
+  background-size: 600px 100%, 800px 100%;
+  opacity: .6;
+  mix-blend-mode: screen;
+}
+
+/* Floating particles */
+.particles-canvas {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.hero__inner {
+  width: 100%;
+  padding-top: 8rem;
+  padding-bottom: 3rem;
+  position: relative;
+  z-index: 1;
+}
+.hero__eyebrow {
+  margin-bottom: 1.5rem;
+  opacity: 0;
+  transform: translateY(20px);
+  animation: rise .9s var(--ease-out) .1s forwards;
+}
+.hero__title {
+  font-family: var(--display);
+  font-size: clamp(3.5rem, 9vw, 9.5rem);
+  font-weight: 500;
+  line-height: .95;
+  letter-spacing: -.02em;
+  font-variation-settings: "opsz" 144, "SOFT" 50;
+  margin-bottom: 1.5rem;
+  max-width: 14ch;
+}
+.hero__title em {
+  font-style: italic;
+  font-weight: 500;
+  color: var(--amber-400);
+  font-variation-settings: "opsz" 144;
+}
+.hero__title > span {
+  display: block;
+  opacity: 0;
+  transform: translateY(30px);
+  animation: rise 1s var(--ease-out) forwards;
+}
+.hero__title > span:nth-child(1) { animation-delay: .2s; }
+.hero__title > span:nth-child(2) { animation-delay: .35s; }
+
+.hero__lede {
+  max-width: 52ch;
+  font-size: clamp(1.05rem, 1.4vw, 1.25rem);
+  line-height: 1.55;
+  color: rgba(246, 242, 231, .85);
+  margin-bottom: 2.25rem;
+  opacity: 0;
+  transform: translateY(20px);
+  animation: rise .9s var(--ease-out) .55s forwards;
+}
+
+.hero__ctas {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 3.5rem;
+  opacity: 0;
+  transform: translateY(20px);
+  animation: rise .9s var(--ease-out) .7s forwards;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: .55rem;
+  padding: .95rem 1.6rem;
+  font-size: .9375rem;
+  font-weight: 600;
+  border-radius: var(--radius-pill);
+  transition: background .2s, color .2s, transform .2s, border-color .2s, box-shadow .2s;
+  border: 1.5px solid transparent;
+  white-space: nowrap;
+}
+.btn svg { width: 16px; height: 16px; }
+.btn--primary {
+  background: var(--amber-500);
+  color: var(--forest-900);
+}
+.btn--primary:hover { background: var(--amber-400); transform: translateY(-1px); box-shadow: 0 8px 24px -8px rgba(212, 160, 74, .4); }
+.btn--ghost {
+  background: transparent;
+  color: var(--cream-50);
+  border-color: rgba(246, 242, 231, .35);
+}
+.btn--ghost:hover { border-color: var(--cream-50); background: rgba(246, 242, 231, .08); }
+.btn--docs {
+  background: rgba(62, 123, 87, .2);
+  color: var(--cream-50);
+  border-color: rgba(62, 123, 87, .4);
+}
+.btn--docs:hover { background: rgba(62, 123, 87, .35); border-color: var(--moss-400); transform: translateY(-1px); }
+.btn--sponsor {
+  background: linear-gradient(135deg, var(--moss-500), var(--forest-600));
+  color: var(--cream-50);
+  border: none;
+}
+.btn--sponsor:hover { transform: translateY(-2px); box-shadow: 0 8px 24px -6px rgba(62, 123, 87, .4); }
+
+.hero__terminal {
+  display: inline-flex;
+  align-items: center;
+  gap: .65rem;
+  padding: .7rem 1.1rem;
+  background: rgba(15, 31, 21, .55);
+  border: 1px solid rgba(246, 242, 231, .18);
+  border-radius: var(--radius-md);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  font-family: var(--mono);
+  font-size: .95rem;
+  color: rgba(246, 242, 231, .9);
+  opacity: 0;
+  transform: translateY(20px);
+  animation: rise .9s var(--ease-out) .85s forwards;
+  max-width: 100%;
+  overflow: hidden;
+}
+.hero__terminal .prompt { color: var(--moss-400); }
+.hero__terminal .caret {
+  display: inline-block;
+  width: 8px;
+  height: 1em;
+  background: var(--amber-400);
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  animation: blink 1.1s steps(2) infinite;
+}
+
+.hero__scroll {
+  position: absolute;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: .5rem;
+  font-size: .7rem;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: rgba(246, 242, 231, .6);
+}
+.hero__scroll::after {
+  content: "";
+  width: 1px;
+  height: 36px;
+  background: linear-gradient(180deg, rgba(246, 242, 231, .6), transparent);
+}
+
+/* ============================================================
+   Stats Strip
+   ============================================================ */
+.stats {
+  background: var(--cream-50);
+  border-top: 1px solid rgba(15, 31, 21, .08);
+  border-bottom: 1px solid rgba(15, 31, 21, .08);
+  padding: 3.5rem 0;
+}
+.stats__grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 2rem;
+}
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: .35rem;
+  padding-left: 1.5rem;
+  border-left: 1px solid rgba(15, 31, 21, .12);
+}
+.stat:first-child { border-left: 0; padding-left: 0; }
+.stat__num {
+  font-family: var(--display);
+  font-size: clamp(2.5rem, 4.5vw, 3.5rem);
+  font-weight: 500;
+  font-variation-settings: "opsz" 144;
+  letter-spacing: -.02em;
+  color: var(--ink);
+  line-height: 1;
+}
+.stat__num sup {
+  font-family: var(--body);
+  font-size: .45em;
+  color: var(--moss-500);
+  font-weight: 600;
+  margin-left: .1em;
+  vertical-align: super;
+}
+.stat__label {
+  font-size: .875rem;
+  color: var(--ink-soft);
+  font-weight: 500;
+}
+.stat__sub {
+  font-size: .75rem;
+  color: var(--moss-500);
+  font-family: var(--mono);
+  letter-spacing: .04em;
+  margin-top: .15rem;
+}
+
+/* ============================================================
+   Sections & Layout
+   ============================================================ */
+.section {
+  padding: var(--section-y) 0;
+  position: relative;
+}
+.section--dark {
+  background: var(--forest-900);
+  color: var(--cream-50);
+}
+.section--cream {
+  background: var(--cream-100);
+}
+.section--sage {
+  background: var(--sage-100);
+}
+
+.section__head {
+  max-width: 720px;
+  margin: 0 auto 4rem;
+  text-align: center;
+}
+.section__head .eyebrow { margin-bottom: 1rem; }
+.section__head h2 {
+  font-family: var(--display);
+  font-size: clamp(2rem, 4.5vw, 3.75rem);
+  font-weight: 500;
+  line-height: 1.05;
+  letter-spacing: -.02em;
+  font-variation-settings: "opsz" 144;
+  margin-bottom: 1rem;
+}
+.section__head h2 em { font-style: italic; color: var(--moss-500); }
+.section--dark .section__head h2 em { color: var(--amber-400); }
+.section__head p {
+  font-size: 1.0625rem;
+  color: var(--ink-soft);
+  line-height: 1.6;
+}
+.section--dark .section__head p { color: rgba(246, 242, 231, .75); }
+
+/* ============================================================
+   Cards & Grids
+   ============================================================ */
+.intro__grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+.intro-card {
+  background: var(--cream-50);
+  border: 1px solid rgba(15, 31, 21, .08);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  position: relative;
+  transition: transform .3s var(--ease-out), box-shadow .3s, border-color .3s;
+}
+.intro-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-md);
+  border-color: rgba(62, 123, 87, .35);
+}
+.intro-card__icon {
+  width: 48px; height: 48px;
+  border-radius: var(--radius-sm);
+  background: var(--sage-200);
+  color: var(--forest-900);
+  display: grid;
+  place-items: center;
+  margin-bottom: 1.5rem;
+}
+.intro-card__icon svg { width: 24px; height: 24px; }
+.intro-card h3 {
+  font-family: var(--display);
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -.01em;
+  margin-bottom: .65rem;
+}
+.intro-card p { color: var(--ink-soft); font-size: .9375rem; }
+
+.features__grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+}
+.feature {
+  background: var(--forest-800);
+  border: 1px solid var(--forest-700);
+  border-radius: var(--radius-md);
+  padding: 1.75rem;
+  position: relative;
+  transition: border-color .25s, transform .25s;
+  overflow: hidden;
+}
+.feature::before {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  background: linear-gradient(135deg, var(--moss-500), transparent 50%);
+  border-radius: var(--radius-md);
+  opacity: 0;
+  transition: opacity .3s;
+  z-index: -1;
+}
+.feature:hover {
+  border-color: rgba(62, 123, 87, .6);
+  transform: translateY(-3px);
+}
+.feature__tag {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: .7rem;
+  font-weight: 500;
+  color: var(--amber-400);
+  background: rgba(212, 160, 74, .12);
+  padding: .2rem .55rem;
+  border-radius: var(--radius-pill);
+  margin-bottom: 1rem;
+  letter-spacing: .04em;
+}
+.feature h3 {
+  font-family: var(--display);
+  font-size: 1.375rem;
+  font-weight: 500;
+  letter-spacing: -.01em;
+  margin-bottom: .6rem;
+  color: var(--cream-50);
+}
+.feature p {
+  color: rgba(246, 242, 231, .7);
+  font-size: .9375rem;
+  line-height: 1.55;
+}
+.feature code {
+  font-family: var(--mono);
+  font-size: .8rem;
+  color: var(--moss-400);
+  background: rgba(62, 123, 87, .12);
+  padding: .1rem .35rem;
+  border-radius: 3px;
+}
+
+/* ============================================================
+   Quick Start
+   ============================================================ */
+.quickstart {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+  background: var(--forest-900);
+  border: 1px solid var(--forest-700);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-lg);
+}
+.tabs {
+  display: flex;
+  gap: .25rem;
+  border-bottom: 1px solid var(--forest-700);
+  padding-bottom: .75rem;
+  flex-wrap: wrap;
+}
+.tab {
+  font-family: var(--body);
+  font-size: .875rem;
+  font-weight: 500;
+  color: rgba(246, 242, 231, .55);
+  padding: .5rem .9rem;
+  border-radius: var(--radius-pill);
+  transition: color .2s, background .2s;
+  display: inline-flex;
+  align-items: center;
+  gap: .5rem;
+}
+.tab svg { width: 14px; height: 14px; }
+.tab:hover { color: var(--cream-50); }
+.tab.is-active {
+  color: var(--forest-900);
+  background: var(--amber-400);
+}
+.tab__panel {
+  display: none;
+  font-family: var(--mono);
+  font-size: .9rem;
+  line-height: 1.7;
+  color: rgba(246, 242, 231, .9);
+  padding: .5rem .25rem 0;
+  overflow-x: auto;
+}
+.tab__panel.is-active { display: block; }
+.tab__panel pre { white-space: pre; }
+
+.quickstart__aside {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin-top: 1rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--forest-700);
+}
+.quickstart__stat {
+  font-family: var(--mono);
+  font-size: .75rem;
+  color: rgba(246, 242, 231, .6);
+  display: flex;
+  flex-direction: column;
+  gap: .15rem;
+}
+.quickstart__stat strong {
+  font-family: var(--display);
+  font-size: 1.25rem;
+  font-weight: 500;
+  color: var(--amber-400);
+}
+
+.tok-kw { color: #E5BD7A; }
+.tok-fn { color: #9DCFAF; }
+.tok-st { color: #D08866; }
+.tok-cm { color: #6B7B70; font-style: italic; }
+.tok-nm { color: #DCE6DD; }
+.tok-op { color: rgba(246, 242, 231, .7); }
+
+/* ============================================================
+   Visual Showcase
+   ============================================================ */
+.showcase__grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+  align-items: stretch;
+}
+.showcase__card {
+  background: var(--cream-50);
+  border: 1px solid rgba(15, 31, 21, .08);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transition: transform .3s, box-shadow .3s;
+}
+.showcase__card:hover { transform: translateY(-4px); box-shadow: var(--shadow-md); }
+.showcase__media {
+  background: linear-gradient(180deg, var(--cream-100), var(--cream-50));
+  aspect-ratio: 16/9;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  border-bottom: 1px solid rgba(15, 31, 21, .06);
+}
+.showcase__media img { max-height: 100%; width: auto; }
+.showcase__body { padding: 1.5rem; }
+.showcase__body h3 {
+  font-family: var(--display);
+  font-size: 1.4rem;
+  font-weight: 500;
+  letter-spacing: -.01em;
+  margin-bottom: .5rem;
+}
+.showcase__body p { color: var(--ink-soft); font-size: .9375rem; }
+
+/* ============================================================
+   Comparison Table
+   ============================================================ */
+.compare-wrap { overflow-x: auto; }
+.compare {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: var(--cream-50);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+  font-size: .9375rem;
+  min-width: 720px;
+}
+.compare th, .compare td {
+  padding: 1.1rem 1.4rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(15, 31, 21, .08);
+}
+.compare th {
+  font-family: var(--body);
+  font-size: .75rem;
+  font-weight: 600;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  background: var(--cream-100);
+}
+.compare th.col-us {
+  background: var(--forest-900);
+  color: var(--cream-50);
+  position: relative;
+}
+.compare th.col-us::after {
+  content: "v1.4.0";
+  position: absolute;
+  top: .35rem; right: .8rem;
+  font-family: var(--mono);
+  font-size: .65rem;
+  color: var(--amber-400);
+  letter-spacing: 0;
+  text-transform: none;
+}
+.compare td.col-us {
+  background: rgba(62, 123, 87, .06);
+  font-weight: 500;
+  color: var(--ink);
+}
+.compare tbody tr:last-child th, .compare tbody tr:last-child td { border-bottom: 0; }
+.compare td.feature-name {
+  font-weight: 500;
+  color: var(--ink);
+}
+.icon-yes { color: var(--moss-500); }
+.icon-no  { color: var(--terracotta-500); }
+.icon-yes svg, .icon-no svg { width: 18px; height: 18px; display: inline-block; vertical-align: -3px; }
+
+/* ============================================================
+   CI/CD Gate
+   ============================================================ */
+.cicd__grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+  align-items: stretch;
+}
+.terminal {
+  background: var(--forest-900);
+  color: var(--cream-50);
+  border-radius: var(--radius-md);
+  font-family: var(--mono);
+  font-size: .85rem;
+  line-height: 1.7;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--forest-700);
+}
+.terminal__bar {
+  background: var(--forest-800);
+  padding: .7rem 1rem;
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  font-size: .75rem;
+  color: rgba(246, 242, 231, .6);
+  border-bottom: 1px solid var(--forest-700);
+}
+.terminal__bar .dots { display: flex; gap: .35rem; }
+.terminal__bar .dot { width: 10px; height: 10px; border-radius: 50%; }
+.terminal__bar .dot.r { background: #E97070; }
+.terminal__bar .dot.y { background: #E2C064; }
+.terminal__bar .dot.g { background: #9DCFAF; }
+.terminal__bar .label { margin-left: auto; font-family: var(--body); letter-spacing: .04em; }
+.terminal__body { padding: 1.25rem 1.25rem 1.5rem; overflow-x: auto; }
+.terminal__body pre { white-space: pre; }
+.terminal__body .ok { color: #9DCFAF; }
+.terminal__body .warn { color: #E5BD7A; }
+.terminal__body .err { color: #E97070; }
+.terminal__body .cm { color: #6B7B70; font-style: italic; }
+
+.cicd__copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1rem 0;
+}
+.cicd__copy h3 {
+  font-family: var(--display);
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+  font-weight: 500;
+  letter-spacing: -.02em;
+  line-height: 1.1;
+  margin-bottom: 1rem;
+}
+.cicd__copy h3 em { font-style: italic; color: var(--moss-500); }
+.cicd__copy p { color: var(--ink-soft); font-size: 1.0625rem; margin-bottom: 1.5rem; }
+.cicd__copy ul { list-style: none; display: flex; flex-direction: column; gap: .65rem; }
+.cicd__copy li {
+  display: flex;
+  align-items: flex-start;
+  gap: .65rem;
+  color: var(--ink-soft);
+  font-size: .9375rem;
+}
+.cicd__copy li svg { flex: 0 0 18px; color: var(--moss-500); margin-top: 3px; }
+
+/* ============================================================
+   Resources / Documentation Grid
+   ============================================================ */
+.resources__grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.25rem;
+}
+.resource-card {
+  background: var(--forest-800);
+  border: 1px solid var(--forest-700);
+  border-radius: var(--radius-md);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: .75rem;
+  transition: transform .3s var(--ease-out), border-color .3s, box-shadow .3s;
+  position: relative;
+  overflow: hidden;
+}
+.resource-card::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--moss-500), var(--amber-400));
+  opacity: 0;
+  transition: opacity .3s;
+}
+.resource-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(62, 123, 87, .5);
+  box-shadow: 0 16px 40px -12px rgba(15, 31, 21, .3);
+}
+.resource-card:hover::before { opacity: 1; }
+.resource-card__icon {
+  width: 44px; height: 44px;
+  border-radius: var(--radius-sm);
+  display: grid;
+  place-items: center;
+  background: var(--forest-700);
+  color: var(--amber-400);
+}
+.resource-card__icon svg { width: 22px; height: 22px; }
+.resource-card h3 {
+  font-family: var(--display);
+  font-size: 1.25rem;
+  font-weight: 500;
+  color: var(--cream-50);
+}
+.resource-card p {
+  font-size: .875rem;
+  color: rgba(246, 242, 231, .65);
+  line-height: 1.5;
+  flex: 1;
+}
+.resource-card__link {
+  display: inline-flex;
+  align-items: center;
+  gap: .4rem;
+  font-size: .8125rem;
+  font-weight: 600;
+  color: var(--amber-400);
+  transition: gap .25s;
+  align-self: flex-start;
+}
+.resource-card__link:hover { gap: .65rem; }
+.resource-card__link svg { width: 14px; height: 14px; }
+
+/* ============================================================
+   Live Dashboard
+   ============================================================ */
+.dashboard {
+  background: var(--forest-900);
+  position: relative;
+  overflow: hidden;
+}
+.dashboard__particles {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.dashboard__locked {
+  text-align: center;
+  padding: 3rem 0;
+  position: relative;
+  z-index: 1;
+}
+.dashboard__locked-icon {
+  width: 64px; height: 64px;
+  margin: 0 auto 1.5rem;
+  border-radius: 50%;
+  background: rgba(62, 123, 87, .12);
+  display: grid;
+  place-items: center;
+  color: var(--moss-400);
+}
+.dashboard__locked-icon svg { width: 28px; height: 28px; }
+.dashboard__locked h3 {
+  font-family: var(--display);
+  font-size: 1.5rem;
+  font-weight: 500;
+  color: var(--cream-50);
+  margin-bottom: .5rem;
+}
+.dashboard__locked p {
+  color: rgba(246, 242, 231, .6);
+  margin-bottom: 1.5rem;
+  font-size: .9375rem;
+}
+
+.dashboard__content {
+  display: none;
+  position: relative;
+  z-index: 1;
+}
+.dashboard__content.is-visible { display: block; }
+
+.dashboard__metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.25rem;
+  margin-bottom: 2rem;
+}
+.metric-card {
+  background: rgba(22, 38, 27, .7);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid var(--forest-700);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+  transition: border-color .3s, transform .3s;
+}
+.metric-card:hover {
+  border-color: rgba(62, 123, 87, .4);
+  transform: translateY(-2px);
+}
+.metric-card__label {
+  font-size: .75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .12em;
+  color: rgba(246, 242, 231, .5);
+}
+.metric-card__value {
+  font-family: var(--display);
+  font-size: 2rem;
+  font-weight: 500;
+  color: var(--cream-50);
+  line-height: 1;
+  font-variation-settings: "opsz" 144;
+}
+.metric-card__value .unit {
+  font-size: .5em;
+  color: var(--moss-400);
+  font-weight: 600;
+  margin-left: .15em;
+}
+.metric-card__change {
+  font-family: var(--mono);
+  font-size: .7rem;
+  display: inline-flex;
+  align-items: center;
+  gap: .25rem;
+}
+.metric-card__change.up { color: #E97070; }
+.metric-card__change.down { color: #9DCFAF; }
+
+.progress-ring-wrap {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.progress-ring {
+  width: 56px; height: 56px;
+  flex-shrink: 0;
+}
+.progress-ring circle {
+  fill: none;
+  stroke-width: 4;
+  stroke-linecap: round;
+}
+.progress-ring .bg { stroke: var(--forest-700); }
+.progress-ring .fg {
+  stroke: var(--moss-400);
+  transition: stroke-dashoffset .8s var(--ease-out);
+}
+
+.dashboard__main {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 1.5rem;
+}
+
+.dashboard__chart-card {
+  background: rgba(22, 38, 27, .7);
+  backdrop-filter: blur(10px);
+  border: 1px solid var(--forest-700);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.dashboard__chart-header {
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--forest-700);
+}
+.dashboard__chart-header h4 {
+  font-family: var(--display);
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: var(--cream-50);
+}
+.dashboard__chart-header .live-dot {
+  display: inline-flex;
+  align-items: center;
+  gap: .4rem;
+  font-size: .7rem;
+  font-family: var(--mono);
+  color: #9DCFAF;
+  letter-spacing: .04em;
+}
+.dashboard__chart-header .live-dot::before {
+  content: "";
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: #9DCFAF;
+  animation: pulse-dot 2s ease-in-out infinite;
+}
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(157, 207, 175, .5); }
+  50% { opacity: .7; box-shadow: 0 0 0 6px rgba(157, 207, 175, 0); }
+}
+.dashboard__chart-body {
+  padding: 1rem 1.5rem 1.5rem;
+  height: 240px;
+  position: relative;
+}
+.dashboard__chart-body canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.dashboard__table-card {
+  background: rgba(22, 38, 27, .7);
+  backdrop-filter: blur(10px);
+  border: 1px solid var(--forest-700);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.dashboard__table-header {
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--forest-700);
+}
+.dashboard__table-header h4 {
+  font-family: var(--display);
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: var(--cream-50);
+}
+.dashboard__table-body {
+  flex: 1;
+  overflow-y: auto;
+  max-height: 300px;
+}
+.fn-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: .8125rem;
+}
+.fn-table th {
+  position: sticky;
+  top: 0;
+  background: var(--forest-800);
+  padding: .65rem 1rem;
+  text-align: left;
+  font-weight: 600;
+  font-size: .7rem;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: rgba(246, 242, 231, .5);
+  border-bottom: 1px solid var(--forest-700);
+}
+.fn-table td {
+  padding: .6rem 1rem;
+  color: rgba(246, 242, 231, .8);
+  border-bottom: 1px solid rgba(30, 51, 36, .5);
+  font-family: var(--mono);
+  font-size: .75rem;
+}
+.fn-table tr:last-child td { border-bottom: none; }
+.fn-table tr {
+  transition: background .15s;
+}
+.fn-table tbody tr:hover { background: rgba(62, 123, 87, .06); }
+.fn-name { color: var(--moss-400); }
+.fn-status {
+  display: inline-block;
+  padding: .1rem .4rem;
+  border-radius: var(--radius-sm);
+  font-size: .65rem;
+  font-weight: 600;
+  letter-spacing: .03em;
+}
+.fn-status.ok { background: rgba(157, 207, 175, .15); color: #9DCFAF; }
+.fn-status.warn { background: rgba(229, 189, 122, .15); color: #E5BD7A; }
+.fn-status.err { background: rgba(233, 112, 112, .15); color: #E97070; }
+
+.dashboard__code-card {
+  margin-top: 1.5rem;
+  background: rgba(22, 38, 27, .7);
+  backdrop-filter: blur(10px);
+  border: 1px solid var(--forest-700);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.dashboard__code-header {
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--forest-700);
+}
+.dashboard__code-header h4 {
+  font-family: var(--display);
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: var(--cream-50);
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+}
+.dashboard__code-header .file-tag {
+  font-family: var(--mono);
+  font-size: .7rem;
+  color: var(--amber-400);
+  background: rgba(212, 160, 74, .12);
+  padding: .15rem .5rem;
+  border-radius: var(--radius-pill);
+  font-weight: 500;
+}
+.dashboard__code-body {
+  padding: 1.25rem 1.5rem;
+  font-family: var(--mono);
+  font-size: .8rem;
+  line-height: 1.8;
+  color: rgba(246, 242, 231, .9);
+  overflow-x: auto;
+}
+.dashboard__code-body pre {
+  white-space: pre;
+  counter-reset: line;
+}
+.dashboard__code-body .line {
+  display: block;
+}
+.dashboard__code-body .line::before {
+  counter-increment: line;
+  content: counter(line);
+  display: inline-block;
+  width: 2.5em;
+  text-align: right;
+  margin-right: 1.5em;
+  color: rgba(246, 242, 231, .25);
+  user-select: none;
+}
+.dashboard__code-body .line.highlight {
+  background: rgba(62, 123, 87, .12);
+  margin: 0 -1.5rem;
+  padding: 0 1.5rem;
+  border-left: 2px solid var(--moss-400);
+}
+
+/* ============================================================
+   Sponsorship Section
+   ============================================================ */
+.sponsor-section {
+  background: linear-gradient(135deg, var(--forest-900) 0%, #1a2f20 50%, var(--forest-900) 100%);
+  position: relative;
+  overflow: hidden;
+}
+.sponsor-section::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 20% 50%, rgba(62, 123, 87, .1), transparent 50%),
+    radial-gradient(circle at 80% 50%, rgba(212, 160, 74, .08), transparent 50%);
+  pointer-events: none;
+}
+.sponsor__inner {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4rem;
+  align-items: center;
+  position: relative;
+  z-index: 1;
+}
+.sponsor__copy h2 {
+  font-family: var(--display);
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 500;
+  line-height: 1.1;
+  letter-spacing: -.02em;
+  color: var(--cream-50);
+  margin-bottom: 1rem;
+}
+.sponsor__copy h2 em {
+  font-style: italic;
+  color: var(--amber-400);
+}
+.sponsor__copy p {
+  color: rgba(246, 242, 231, .7);
+  font-size: 1.0625rem;
+  line-height: 1.6;
+  margin-bottom: 2rem;
+  max-width: 48ch;
+}
+.sponsor__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.sponsor__tiers {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+.sponsor-tier {
+  background: rgba(22, 38, 27, .6);
+  border: 1px solid var(--forest-700);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  text-align: center;
+  transition: transform .3s, border-color .3s;
+}
+.sponsor-tier:hover {
+  transform: translateY(-3px);
+  border-color: rgba(62, 123, 87, .4);
+}
+.sponsor-tier__emoji {
+  font-size: 2rem;
+  margin-bottom: .5rem;
+}
+.sponsor-tier h4 {
+  font-family: var(--display);
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: var(--cream-50);
+  margin-bottom: .25rem;
+}
+.sponsor-tier__price {
+  font-family: var(--mono);
+  font-size: .8rem;
+  color: var(--amber-400);
+  margin-bottom: .5rem;
+}
+.sponsor-tier p {
+  font-size: .8rem;
+  color: rgba(246, 242, 231, .55);
+  line-height: 1.4;
+}
+
+/* ============================================================
+   Ecosystem
+   ============================================================ */
+.eco__grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+}
+.eco-tile {
+  background: var(--forest-800);
+  color: var(--cream-50);
+  border: 1px solid var(--forest-700);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  position: relative;
+  overflow: hidden;
+  transition: transform .3s, border-color .3s;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 240px;
+}
+.eco-tile::after {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  background: radial-gradient(circle at 100% 0%, rgba(212, 160, 74, .15), transparent 60%);
+  pointer-events: none;
+}
+.eco-tile:hover { transform: translateY(-4px); border-color: var(--moss-500); }
+.eco-tile__icon {
+  width: 44px; height: 44px;
+  border-radius: var(--radius-sm);
+  display: grid;
+  place-items: center;
+  background: var(--forest-700);
+  color: var(--amber-400);
+}
+.eco-tile__icon svg { width: 22px; height: 22px; }
+.eco-tile h3 {
+  font-family: var(--display);
+  font-size: 1.375rem;
+  font-weight: 500;
+  letter-spacing: -.01em;
+}
+.eco-tile p {
+  color: rgba(246, 242, 231, .7);
+  font-size: .9375rem;
+  line-height: 1.55;
+  flex: 1;
+}
+.eco-tile__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: .5rem;
+  font-size: .875rem;
+  font-weight: 600;
+  color: var(--amber-400);
+  align-self: flex-start;
+  transition: gap .25s;
+}
+.eco-tile__cta:hover { gap: .75rem; }
+.eco-tile__cta svg { width: 14px; height: 14px; }
+
+/* ============================================================
+   Footer
+   ============================================================ */
+.footer {
+  background: var(--forest-900);
+  color: var(--cream-50);
+  padding: 4rem 0 2rem;
+  border-top: 1px solid var(--forest-700);
+}
+.footer__top {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr 1fr 1fr;
+  gap: 2rem;
+  margin-bottom: 3rem;
+}
+.footer__brand {
+  display: flex;
+  align-items: center;
+  gap: .65rem;
+  font-family: var(--display);
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+.footer__brand img { width: 32px; height: 32px; }
+.footer__tag {
+  color: rgba(246, 242, 231, .65);
+  font-size: .9375rem;
+  max-width: 32ch;
+  line-height: 1.55;
+}
+.footer h4 {
+  font-family: var(--body);
+  font-size: .75rem;
+  font-weight: 600;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--amber-400);
+  margin-bottom: 1rem;
+}
+.footer ul { list-style: none; display: flex; flex-direction: column; gap: .55rem; }
+.footer a { color: rgba(246, 242, 231, .7); font-size: .9375rem; transition: color .2s; }
+.footer a:hover { color: var(--cream-50); }
+.footer__sponsor-link {
+  display: inline-flex;
+  align-items: center;
+  gap: .4rem;
+  color: var(--moss-400) !important;
+  font-weight: 600;
+}
+.footer__sponsor-link:hover { color: var(--amber-400) !important; }
+.footer__bottom {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--forest-700);
+  font-size: .8125rem;
+  color: rgba(246, 242, 231, .55);
+}
+.footer__bottom em { font-style: italic; color: var(--amber-400); }
+
+/* ============================================================
+   Scroll Reveals & Animations
+   ============================================================ */
+.reveal {
+  opacity: 0;
+  transform: translateY(40px);
+  transition: opacity .7s var(--ease-out), transform .7s var(--ease-out);
+}
+.reveal.is-in {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 980px) {
+  .dashboard__metrics { grid-template-columns: repeat(2, 1fr); }
+  .dashboard__main { grid-template-columns: 1fr; }
+  .sponsor__inner { grid-template-columns: 1fr; gap: 2rem; }
+  .sponsor__tiers { grid-template-columns: 1fr; }
+  .resources__grid { grid-template-columns: repeat(2, 1fr); }
+  .footer__top { grid-template-columns: 1fr 1fr; }
+  .footer__brand { grid-column: 1 / -1; }
+}
+
+@media (max-width: 640px) {
+  .dashboard__metrics { grid-template-columns: 1fr; }
+  .resources__grid { grid-template-columns: 1fr; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    transition-duration: 0s !important;
+  }
+  .reveal { opacity: 1; transform: none; }
+}
+
+@keyframes rise {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes blink {
+  50% { opacity: 0; }
+}

--- a/landing/dashboard.html
+++ b/landing/dashboard.html
@@ -1,0 +1,219 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+<title>EcoTrace — Live Carbon Dashboard</title>
+<meta name="theme-color" content="#0F1F15" />
+<link rel="icon" type="image/svg+xml" href="./imgs/logo.svg" />
+
+<!-- Preconnect for performance -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,500&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" />
+
+<!-- Load separated modular CSS stylesheet -->
+<link rel="stylesheet" href="./css/styles.css" />
+</head>
+<body style="background: var(--forest-900);">
+
+<!-- Scroll progress bar -->
+<div class="scroll-progress" id="scrollProgress"></div>
+
+<!-- ======================== NAV ======================== -->
+<nav class="nav is-scrolled" id="nav" style="background: rgba(15, 31, 21, .85);">
+  <div class="container nav__inner">
+    <a href="./index.html" class="nav__brand">
+      <img src="./imgs/logo-transparent.png" alt="EcoTrace" onerror="this.style.display='none'" />
+      <span style="color: var(--cream-50);">EcoTrace</span>
+      <small>v1.4</small>
+    </a>
+    <ul class="nav__links">
+      <li><a href="./index.html#features" style="color: rgba(246, 242, 231, .8);">Features</a></li>
+      <li><a href="#dashboard" style="color: var(--cream-50);">Dashboard</a></li>
+      <li><a href="./index.html#start" style="color: rgba(246, 242, 231, .8);">Quick start</a></li>
+      <li><a href="./index.html#compare" style="color: rgba(246, 242, 231, .8);">Compare</a></li>
+      <li><a href="./index.html#resources" style="color: rgba(246, 242, 231, .8);">Docs</a></li>
+    </ul>
+    <div class="nav__actions">
+      <a class="nav__sponsor" href="https://github.com/sponsors/Zwony" target="_blank" rel="noopener">
+        <svg class="heart-pulse" viewBox="0 0 24 24" fill="currentColor"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
+        Sponsor
+      </a>
+      <a class="nav__cta" href="https://github.com/Zwony/ecotrace" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.13c-3.2.7-3.88-1.36-3.88-1.36-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.2 1.77 1.2 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.28 1.18-3.09-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.18 1.18a11 11 0 015.78 0c2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.11 3.04.74.81 1.18 1.83 1.18 3.09 0 4.42-2.69 5.4-5.25 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56C20.21 21.38 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
+        Star on GitHub
+      </a>
+      <!-- Logged-in profile -->
+      <div class="nav__user" id="navUser" onclick="toggleUserDropdown()">
+        <div class="nav__user-avatar" id="navUserAvatar">EO</div>
+        <span id="navUserName" style="color: var(--cream-50);">User</span>
+        <div class="nav__user-dropdown" id="navUserDropdown">
+          <a href="./index.html">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            Home Page
+          </a>
+          <a href="https://ecotrace.readthedocs.io/en/latest/" target="_blank" rel="noopener">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+            Documentation
+          </a>
+          <button onclick="signOut()">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+            Sign Out
+          </button>
+        </div>
+      </div>
+      <!-- Hamburger -->
+      <button class="nav__hamburger" id="hamburger" onclick="toggleMobileNav()" aria-label="Toggle menu">
+        <span style="background: var(--cream-50);"></span>
+        <span style="background: var(--cream-50);"></span>
+        <span style="background: var(--cream-50);"></span>
+      </button>
+    </div>
+  </div>
+</nav>
+
+<!-- Mobile Nav Overlay -->
+<div class="mobile-nav" id="mobileNav">
+  <a href="./index.html#features" onclick="closeMobileNav()">Features</a>
+  <a href="#dashboard" onclick="closeMobileNav()">Dashboard</a>
+  <a href="./index.html#start" onclick="closeMobileNav()">Quick Start</a>
+  <a href="./index.html#compare" onclick="closeMobileNav()">Compare</a>
+  <a href="./index.html#resources" onclick="closeMobileNav()">Docs</a>
+  <a href="https://github.com/sponsors/Zwony" target="_blank" rel="noopener" onclick="closeMobileNav()" style="color:var(--amber-400);">♥ Sponsor</a>
+  <a href="https://github.com/Zwony/ecotrace" target="_blank" rel="noopener" onclick="closeMobileNav()">GitHub</a>
+</div>
+
+<!-- ======================== LIVE DASHBOARD CONTENT ======================== -->
+<section class="section dashboard" id="dashboard" style="min-height: 100vh; padding-top: 8rem;">
+  <canvas class="dashboard__particles" id="dashParticles"></canvas>
+  <div class="container">
+    <div class="section__head">
+      <div class="eyebrow on-dark">Live Dashboard</div>
+      <h2 style="color:var(--cream-50);">Your carbon footprint, <em>in real time</em>.</h2>
+      <p style="color:rgba(246,242,231,.7);">Monitor your functions, visualize emission trends, and track your budget — all from a single pane of glass.</p>
+    </div>
+
+    <div class="dashboard__content is-visible" id="dashboardContent">
+      <!-- 4 metric cards -->
+      <div class="dashboard__metrics">
+        <div class="metric-card">
+          <div class="metric-card__label">Total Carbon Emitted</div>
+          <div class="metric-card__value"><span id="metricCarbon">0.000000</span> <span class="unit">gCO₂</span></div>
+          <div class="metric-card__change up" id="metricCarbonChange">↑ +0.000000 /2s window</div>
+        </div>
+        <div class="metric-card">
+          <div class="metric-card__label">Active Sessions</div>
+          <div class="metric-card__value" id="metricSessions">1</div>
+          <div class="metric-card__change down">● running</div>
+        </div>
+        <div class="metric-card">
+          <div class="metric-card__label">Functions Tracked</div>
+          <div class="metric-card__value" id="metricFunctions">8</div>
+          <div class="metric-card__change down">↓ 2 idle</div>
+        </div>
+        <div class="metric-card">
+          <div class="metric-card__label">Budget Usage</div>
+          <div class="progress-ring-wrap">
+            <svg class="progress-ring" viewBox="0 0 56 56">
+              <circle class="bg" cx="28" cy="28" r="24" />
+              <circle class="fg" id="budgetRing" cx="28" cy="28" r="24"
+                stroke-dasharray="150.8"
+                stroke-dashoffset="150.8"
+                transform="rotate(-90 28 28)" />
+            </svg>
+            <div>
+              <div class="metric-card__value" style="font-size:1.5rem;" id="metricBudget">0%</div>
+              <div class="metric-card__change down">of 5.0 gCO₂</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Chart + Table row -->
+      <div class="dashboard__main">
+        <div class="dashboard__chart-card">
+          <div class="dashboard__chart-header">
+            <h4>Carbon Emission Trend</h4>
+            <span class="live-dot">LIVE</span>
+          </div>
+          <div class="dashboard__chart-body">
+            <canvas id="emissionChart"></canvas>
+          </div>
+        </div>
+        <div class="dashboard__table-card">
+          <div class="dashboard__table-header">
+            <h4>Tracked Functions</h4>
+          </div>
+          <div class="dashboard__table-body">
+            <table class="fn-table">
+              <thead>
+                <tr>
+                  <th>Function</th>
+                  <th>gCO₂</th>
+                  <th>Duration</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody id="fnTableBody">
+                <!-- Filled by dashboard.js -->
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <!-- Code Preview -->
+      <div class="dashboard__code-card">
+        <div class="dashboard__code-header">
+          <h4>Your Code <span class="file-tag">main.py</span></h4>
+          <button class="btn btn--ghost" type="button" onclick="generateIngestionKey()">Generate dashboard key</button>
+        </div>
+        <div class="dashboard__code-body">
+<p id="ingestionKeyHelp" style="margin:0 0 1rem;color:rgba(246,242,231,.72);font-size:.85rem;">Generate a personal key once, then add it to the WebhookExporter in your own project. This panel never uses sample measurements.</p>
+<pre id="ingestionKeyOutput" hidden></pre>
+<pre><span class="line"><span class="tok-kw">from</span> <span class="tok-fn">ecotrace</span> <span class="tok-kw">import</span> EcoTrace</span>
+<span class="line"></span>
+<span class="line">eco = <span class="tok-fn">EcoTrace</span>(region_code=<span class="tok-st">"TR"</span>, carbon_limit=<span class="tok-nm">5.0</span>)</span>
+<span class="line"></span>
+<span class="line highlight"><span class="tok-kw">@eco</span>.track</span>
+<span class="line highlight"><span class="tok-kw">def</span> <span class="tok-fn">train_model</span>(data):</span>
+<span class="line highlight">    model = <span class="tok-fn">load_pretrained</span>(<span class="tok-st">"bert-base"</span>)</span>
+<span class="line highlight">    model.<span class="tok-fn">fit</span>(data, epochs=<span class="tok-nm">10</span>)</span>
+<span class="line highlight">    <span class="tok-kw">return</span> model</span>
+<span class="line"></span>
+<span class="line"><span class="tok-kw">@eco</span>.track</span>
+<span class="line"><span class="tok-kw">def</span> <span class="tok-fn">preprocess</span>(raw):</span>
+<span class="line">    <span class="tok-kw">return</span> [<span class="tok-fn">tokenize</span>(r) <span class="tok-kw">for</span> r <span class="tok-kw">in</span> raw]</span>
+<span class="line"></span>
+<span class="line"><span class="tok-kw">@eco</span>.track</span>
+<span class="line"><span class="tok-kw">def</span> <span class="tok-fn">evaluate</span>(model, test_data):</span>
+<span class="line">    <span class="tok-kw">return</span> model.<span class="tok-fn">score</span>(test_data)</span>
+<span class="line"></span>
+<span class="line"><span class="tok-cm"># Pipeline</span></span>
+<span class="line">data = <span class="tok-fn">preprocess</span>(<span class="tok-fn">load_data</span>(<span class="tok-st">"dataset.csv"</span>))</span>
+<span class="line">model = <span class="tok-fn">train_model</span>(data)</span>
+<span class="line"><span class="tok-fn">print</span>(<span class="tok-st">f"Accuracy: </span>{<span class="tok-fn">evaluate</span>(model, data)}<span class="tok-st">"</span>)</span>
+<span class="line"><span class="tok-fn">print</span>(<span class="tok-st">f"Carbon: </span>{eco.total_carbon:.4f}<span class="tok-st"> gCO2"</span>)</span>
+<span class="line">eco.<span class="tok-fn">generate_pdf_report</span>(<span class="tok-st">"audit.pdf"</span>)</span></pre>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ======================== FOOTER ======================== -->
+<footer class="footer">
+  <div class="container">
+    <div class="footer__bottom" style="border-top: none; padding-top: 0;">
+      <span>© 2026 EcoTrace Team. <em>Developed for sustainable software development practices.</em></span>
+      <span>Built with quiet forests and too much coffee.</span>
+    </div>
+  </div>
+</footer>
+
+<!-- Load scripts -->
+<script src="./js/app.js"></script>
+<script src="./js/dashboard.js"></script>
+</body>
+</html>

--- a/landing/index.html
+++ b/landing/index.html
@@ -1,0 +1,721 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+<title>EcoTrace — Measure every watt. Save every gram.</title>
+<meta name="description" content="EcoTrace is a high-precision carbon footprint instrumentation library for Python. Function-level CPU/GPU emission measurement with 50ms continuous sampling, 50+ global zones, and built-in CI/CD gates." />
+<meta name="theme-color" content="#0F1F15" />
+
+<link rel="icon" type="image/svg+xml" href="./imgs/logo.svg" />
+
+<!-- Preconnect for performance -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,500&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" />
+
+<!-- Link to external modular stylesheet -->
+<link rel="stylesheet" href="./css/styles.css" />
+</head>
+<body>
+
+<!-- Scroll progress bar -->
+<div class="scroll-progress" id="scrollProgress"></div>
+
+<!-- ======================== NAV ======================== -->
+<nav class="nav" id="nav">
+  <div class="container nav__inner">
+    <a href="#top" class="nav__brand">
+      <img src="./imgs/logo.png" alt="EcoTrace" />
+      <span>EcoTrace</span>
+    </a>
+    <ul class="nav__links">
+      <li><a href="#features">Features</a></li>
+      <li><a href="./dashboard.html">Dashboard</a></li>
+      <li><a href="#start">Quick start</a></li>
+      <li><a href="#compare">Compare</a></li>
+      <li><a href="#resources">Docs</a></li>
+    </ul>
+    <div class="nav__actions">
+      <a class="nav__sponsor" href="https://github.com/sponsors/Zwony" target="_blank" rel="noopener" title="Sponsor on GitHub">
+        <svg class="heart-pulse" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
+        Sponsor
+      </a>
+      <a class="nav__cta" href="https://github.com/Zwony/ecotrace" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.13c-3.2.7-3.88-1.36-3.88-1.36-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.2 1.77 1.2 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.28 1.18-3.09-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.18 1.18a11 11 0 015.78 0c2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.11 3.04.74.81 1.18 1.83 1.18 3.09 0 4.42-2.69 5.4-5.25 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56C20.21 21.38 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
+        Star on GitHub
+      </a>
+      <!-- Auth button (shown when not logged in) -->
+      <button class="nav__auth-btn" id="navAuthBtn" onclick="openAuthModal()">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+        Sign In
+      </button>
+      <!-- User profile (shown when logged in) -->
+      <div class="nav__user" id="navUser" onclick="toggleUserDropdown()">
+        <div class="nav__user-avatar" id="navUserAvatar">EO</div>
+        <span id="navUserName">User</span>
+        <div class="nav__user-dropdown" id="navUserDropdown">
+          <a href="./dashboard.html">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg>
+            Dashboard
+          </a>
+          <a href="https://ecotrace.readthedocs.io/en/latest/" target="_blank" rel="noopener">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+            Documentation
+          </a>
+          <button onclick="signOut()">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+            Sign Out
+          </button>
+        </div>
+      </div>
+      <!-- Hamburger -->
+      <button class="nav__hamburger" id="hamburger" onclick="toggleMobileNav()" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </div>
+</nav>
+
+<!-- Mobile Nav Overlay -->
+<div class="mobile-nav" id="mobileNav">
+  <a href="#features" onclick="closeMobileNav()">Features</a>
+  <a href="./dashboard.html" onclick="closeMobileNav()">Dashboard</a>
+  <a href="#start" onclick="closeMobileNav()">Quick Start</a>
+  <a href="#compare" onclick="closeMobileNav()">Compare</a>
+  <a href="#resources" onclick="closeMobileNav()">Docs</a>
+  <a href="https://github.com/sponsors/Zwony" target="_blank" rel="noopener" onclick="closeMobileNav()" style="color:var(--amber-400);">♥ Sponsor</a>
+  <a href="https://github.com/Zwony/ecotrace" target="_blank" rel="noopener" onclick="closeMobileNav()">GitHub</a>
+</div>
+
+<!-- ======================== AUTH MODAL ======================== -->
+<div class="auth-overlay" id="authOverlay">
+  <div class="auth-modal">
+    <button class="auth-modal__close" onclick="closeAuthModal()" aria-label="Close">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
+    </button>
+    <div class="auth-modal__header">
+      <img src="./imgs/logo.png" alt="" class="auth-modal__logo" />
+      <h2>Welcome to EcoTrace</h2>
+      <p>Sign in or create an account to access your live dashboard</p>
+    </div>
+
+    <div class="auth-error" id="authError"></div>
+
+    <div class="auth-social auth-social--primary">
+      <button class="auth-social__btn auth-social__btn--github" onclick="socialAuth('github')">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.13c-3.2.7-3.88-1.36-3.88-1.36-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.2 1.77 1.2 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.28 1.18-3.09-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.18 1.18a11 11 0 015.78 0c2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.11 3.04.74.81 1.18 1.83 1.18 3.09 0 4.42-2.69 5.4-5.25 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56C20.21 21.38 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
+        Continue with GitHub
+      </button>
+      <button class="auth-social__btn auth-social__btn--google" onclick="socialAuth('google')">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"/><path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/><path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/><path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/></svg>
+        Continue with Google
+      </button>
+    </div>
+
+    <p class="auth-modal__terms">By continuing, you agree to our <a href="#" onclick="closeAuthModal()">Terms of Service</a> and <a href="#" onclick="closeAuthModal()">Privacy Policy</a>.</p>
+  </div>
+</div>
+
+<!-- ======================== HERO ======================== -->
+<header class="hero" id="top">
+  <video class="hero__video" autoplay muted loop playsinline preload="auto" poster="" aria-hidden="true">
+    <source src="./videos/hero_forest.mp4" type="video/mp4" />
+  </video>
+  <div class="hero__overlay" aria-hidden="true"></div>
+  <canvas class="particles-canvas" id="heroParticles"></canvas>
+  <div class="container hero__inner">
+    <div class="eyebrow on-dark hero__eyebrow">High-precision Python instrumentation · v1.4.0</div>
+    <h1 class="hero__title">
+      <span>Measure <em>every</em> watt.</span>
+      <span>Save every gram.</span>
+    </h1>
+    <p class="hero__lede">
+      EcoTrace is a lightweight, function-level carbon and energy observatory for production Python.
+      No background services, no configuration files — just verified TDP-based measurement at 50&nbsp;ms
+      resolution, with built-in budgets and CI gates.
+    </p>
+    <div class="hero__ctas">
+      <a class="btn btn--primary" href="#start">
+        Get started
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+      </a>
+      <a class="btn btn--docs" href="https://ecotrace.readthedocs.io/en/latest/" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+        Read the Docs
+      </a>
+      <a class="btn btn--ghost" href="./dashboard.html">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg>
+        Live Dashboard
+      </a>
+      <a class="btn btn--sponsor" href="https://github.com/sponsors/Zwony" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" style="width:16px;height:16px;"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
+        Sponsor Us
+      </a>
+    </div>
+    <div class="hero__terminal" role="text" aria-label="Install command">
+      <span class="prompt">$</span>
+      <span>pip install ecotrace</span>
+      <span class="caret"></span>
+    </div>
+  </div>
+  <div class="hero__scroll">Scroll</div>
+</header>
+
+<!-- ======================== STATS ======================== -->
+<section class="stats" aria-label="Key metrics">
+  <div class="container">
+    <div class="stats__grid">
+      <div class="stat reveal">
+        <div class="stat__num" data-count="50" data-suffix="ms">0ms</div>
+        <div class="stat__label">Sampling interval</div>
+        <div class="stat__sub">20× faster than peers</div>
+      </div>
+      <div class="stat reveal">
+        <div class="stat__num" data-count="50" data-suffix="+">0+</div>
+        <div class="stat__label">Global regions</div>
+        <div class="stat__sub">ISO 3166-1 alpha-2</div>
+      </div>
+      <div class="stat reveal">
+        <div class="stat__num" data-count="100" data-suffix="%">0%</div>
+        <div class="stat__label">Process-scoped</div>
+        <div class="stat__sub">Zero system noise</div>
+      </div>
+      <div class="stat reveal">
+        <div class="stat__num">0<span style="font-size:.5em;color:var(--moss-500);">-config</span></div>
+        <div class="stat__label">Setup time</div>
+        <div class="stat__sub">pip install &amp; go</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ======================== INTRO ======================== -->
+<section class="section">
+  <div class="container">
+    <div class="section__head reveal">
+      <div class="eyebrow">What is EcoTrace</div>
+      <h2>A measurement engine, not a marketing <em>widget</em>.</h2>
+      <p>EcoTrace is the only Python library that treats carbon the way serious observability tools treat latency: granular, attributable, and actionable. Every watt your code spends is mapped to a function, a region, and a moment in time.</p>
+    </div>
+    <div class="intro__grid">
+      <article class="intro-card reveal">
+        <div class="intro-card__icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/><path d="M11 8v6M8 11h6"/></svg>
+        </div>
+        <h3>Granular</h3>
+        <p>Per-function CPU and GPU energy via continuous 50&nbsp;ms sampling and TDP-based estimation, attributed to the function that triggered it.</p>
+      </article>
+      <article class="intro-card reveal">
+        <div class="intro-card__icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 22s8-4 8-12V5l-8-3-8 3v5c0 8 8 12 8 12z"/><path d="m9 12 2 2 4-4"/></svg>
+        </div>
+        <h3>Enforceable</h3>
+        <p>Set a carbon budget per session. EcoTrace will call your callback the moment a function blows past it, and fail your CI gate on merge.</p>
+      </article>
+      <article class="intro-card reveal">
+        <div class="intro-card__icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 3v18h18"/><path d="m7 14 4-4 4 4 5-5"/></svg>
+        </div>
+        <h3>Actionable</h3>
+        <p>Audit-ready PDF reports, run-vs-run diff, and optional Gemini-powered insights turn raw gCO₂ into the next code change you'll merge.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<!-- ======================== FEATURES ======================== -->
+<section class="section section--dark" id="features">
+  <div class="container">
+    <div class="section__head reveal">
+      <div class="eyebrow on-dark">v1.4.0 — Feature Release</div>
+      <h2>Six new ways to keep your <em>code</em> honest.</h2>
+      <p>Every release ships the things serious teams asked for: pausable tracking, run comparisons, webhook streams, filtered exports, log hygiene, and a typed summary API. No new mandatory dependencies.</p>
+    </div>
+    <div class="features__grid">
+      <article class="feature reveal">
+        <span class="feature__tag">pausing</span>
+        <h3>Pausing API</h3>
+        <p>Exclude setup and teardown overhead with <code>EcoTrace.pause()</code> and <code>.resume()</code>. Your carbon reading reflects the work, not the boilerplate.</p>
+      </article>
+      <article class="feature reveal">
+        <span class="feature__tag">diff</span>
+        <h3>Run comparisons</h3>
+        <p><code>ecotrace diff</code> puts two runs side by side — duration, gCO₂, per-function cost. Spot regressions before users do.</p>
+      </article>
+      <article class="feature reveal">
+        <span class="feature__tag">webhook</span>
+        <h3>Webhook exporter</h3>
+        <p>Stream emissions to Slack, Teams, Discord or any HTTP endpoint. Realtime, structured, firehose-friendly.</p>
+      </article>
+      <article class="feature reveal">
+        <span class="feature__tag">csv</span>
+        <h3>Filtered CSV export</h3>
+        <p>Slice by <code>--run</code>, <code>--func</code>, or both. Pipe straight into pandas or your warehouse of choice.</p>
+      </article>
+      <article class="feature reveal">
+        <span class="feature__tag">clean</span>
+        <h3>Log maintenance</h3>
+        <p><code>ecotrace clean</code> rotates; <code>ecotrace reset</code> deletes. Disk hygiene without leaving the terminal.</p>
+      </article>
+      <article class="feature reveal">
+        <span class="feature__tag">summary</span>
+        <h3>get_summary API</h3>
+        <p>Programmatic, typed access to every session metric. Perfect for notebooks, dashboards, and CI assertions.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<!-- ======================== QUICK START ======================== -->
+<section class="section section--cream" id="start">
+  <div class="container">
+    <div class="section__head reveal">
+      <div class="eyebrow">Quick start</div>
+      <h2>From <em>pip install</em> to first gCO₂ in 60 seconds.</h2>
+      <p>Three ways to use EcoTrace. Pick the one that matches your day.</p>
+    </div>
+
+    <div class="quickstart reveal" style="max-width:920px;margin:0 auto;">
+      <div class="tabs" role="tablist">
+        <button class="tab is-active" role="tab" data-tab="cli">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="m4 17 6-6-6-6M12 19h8"/></svg>
+          Zero-code CLI
+        </button>
+        <button class="tab" role="tab" data-tab="lib">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="m18 16 4-4-4-4M6 8l-4 4 4 4M14.5 4l-5 16"/></svg>
+          Programmatic
+        </button>
+        <button class="tab" role="tab" data-tab="budget">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 22s8-4 8-12V5l-8-3-8 3v5c0 8 8 12 8 12z"/></svg>
+          Carbon budget
+        </button>
+      </div>
+
+      <div class="tab__panel is-active" data-panel="cli">
+<pre><span class="tok-cm"># Measure any existing script — zero code changes</span>
+$ <span class="tok-fn">ecotrace</span> run train_model.py
+
+<span class="tok-cm">[EcoTrace] Region        : US (385 gCO2/kWh)</span>
+<span class="tok-cm">[EcoTrace] Hardware Logic: 13th Gen Intel Core i7-13700H</span>
+<span class="tok-cm">[EcoTrace] Sampling Rate : 50 ms (continuous)</span>
+
+=======================================================
+  EcoTrace — Session Summary
+=======================================================
+  Duration       : 12.34s
+  Functions      : 5 tracked
+  Total Carbon   : 0.00312000 gCO2
+  Region         : US (385 gCO2/kWh)
+  Budget         : 0.003120 / 5.000000 gCO2 (0.1%) <span class="tok-st">[OK]</span>
+  Equivalent     : 0.4 min of LED bulb (10W)
+=======================================================</pre>
+      </div>
+
+      <div class="tab__panel" data-panel="lib">
+<pre><span class="tok-kw">from</span> <span class="tok-fn">ecotrace</span> <span class="tok-kw">import</span> EcoTrace
+
+eco = <span class="tok-fn">EcoTrace</span>(region_code=<span class="tok-st">"US"</span>)
+
+<span class="tok-kw">@eco</span>.track
+<span class="tok-kw">def</span> <span class="tok-fn">my_function</span>():
+    <span class="tok-cm"># Your heavy processing here</span>
+    ...
+
+<span class="tok-fn">my_function</span>()
+
+<span class="tok-cm"># Export audit-ready reports or check cumulative totals</span>
+eco.<span class="tok-fn">generate_pdf_report</span>(<span class="tok-st">"carbon_audit.pdf"</span>)
+<span class="tok-fn">print</span>(<span class="tok-st">f"Total Carbon Emitted: </span><span class="tok-op">{</span>eco.total_carbon<span class="tok-op">}</span><span class="tok-st"> gCO2"</span>)</pre>
+      </div>
+
+      <div class="tab__panel" data-panel="budget">
+<pre><span class="tok-kw">from</span> <span class="tok-fn">ecotrace</span> <span class="tok-kw">import</span> EcoTrace
+
+eco = <span class="tok-fn">EcoTrace</span>(
+    region_code=<span class="tok-st">"TR"</span>,
+    carbon_limit=<span class="tok-nm">5.0</span>,                  <span class="tok-cm"># 5 gCO2 budget</span>
+    on_budget_exceeded=<span class="tok-kw">lambda</span> t, l:
+        <span class="tok-fn">print</span>(<span class="tok-st">f"Budget exceeded: </span><span class="tok-op">{</span>t<span class="tok-op">:.4f}</span><span class="tok-st">/</span><span class="tok-op">{</span>l<span class="tok-op">:.4f}</span><span class="tok-st"> gCO2"</span>)
+)
+
+<span class="tok-kw">@eco</span>.track
+<span class="tok-kw">def</span> <span class="tok-fn">training_pipeline</span>():
+    ...
+
+<span class="tok-fn">training_pipeline</span>()
+<span class="tok-fn">print</span>(<span class="tok-st">f"Remaining budget: </span><span class="tok-op">{</span>eco.remaining_budget<span class="tok-op">}</span><span class="tok-st"> gCO2"</span>)</pre>
+      </div>
+
+      <div class="quickstart__aside">
+        <div class="quickstart__stat">
+          <strong>3.9 → 3.12+</strong>
+          <span>Python support</span>
+        </div>
+        <div class="quickstart__stat">
+          <strong>MIT</strong>
+          <span>License — yours to keep</span>
+        </div>
+        <div class="quickstart__stat">
+          <strong>50 ms</strong>
+          <span>Sampling — 300× per second</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ======================== VISUAL SHOWCASE ======================== -->
+<section class="section">
+  <div class="container">
+    <div class="section__head reveal">
+      <div class="eyebrow">Visual analytics</div>
+      <h2>Trends you can <em>read</em>, not just file.</h2>
+      <p>Every run ships with structured trend charts. Light runs versus heavy runs, exported PNGs ready to drop into your next postmortem.</p>
+    </div>
+    <div class="showcase__grid">
+      <article class="showcase__card reveal">
+        <div class="showcase__media"><img src="./imgs/light_graph.png" alt="Light run trend chart" loading="lazy" onerror="this.style.display='none'" /></div>
+        <div class="showcase__body">
+          <h3>Light workloads</h3>
+          <p>Short, bursty functions tracked without losing the per-function attribution that helps you decide what to optimize first.</p>
+        </div>
+      </article>
+      <article class="showcase__card reveal">
+        <div class="showcase__media"><img src="./imgs/heavy_graph.png" alt="Heavy run trend chart" loading="lazy" onerror="this.style.display='none'" /></div>
+        <div class="showcase__body">
+          <h3>Heavy workloads</h3>
+          <p>Long-running ML training and ETL pipelines stay observable across millions of samples — no downsampling, no lossy aggregation.</p>
+        </div>
+      </article>
+    </div>
+    <div class="reveal" style="margin-top:3rem;text-align:center;">
+      <img src="./imgs/insights.png" alt="AI-powered carbon insights" style="max-width:100%;height:auto;border-radius:var(--radius-md);box-shadow:var(--shadow-md);" loading="lazy" onerror="this.style.display='none'" />
+      <p style="margin-top:1rem;color:var(--ink-soft);font-size:.9375rem;max-width:60ch;margin-left:auto;margin-right:auto;">
+        Optional <em>ecotrace[ai]</em> extra wires Google Gemini to your run history and proposes the specific code change that will cut the most grams.
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- ======================== COMPARE ======================== -->
+<section class="section section--sage" id="compare">
+  <div class="container">
+    <div class="section__head reveal">
+      <div class="eyebrow">How it compares</div>
+      <h2>The benchmarks don't <em>lie</em>.</h2>
+      <p>Side-by-side against the two most-cited alternatives in the Python ecosystem. Different category of instrument.</p>
+    </div>
+    <div class="compare-wrap reveal">
+      <table class="compare">
+        <thead>
+          <tr>
+            <th>Capability</th>
+            <th class="col-us">EcoTrace</th>
+            <th>CodeCarbon</th>
+            <th>CarbonTracker</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="feature-name">Sampling interval</td>
+            <td class="col-us">50 ms</td>
+            <td>15 s</td>
+            <td>Per epoch</td>
+          </tr>
+          <tr>
+            <td class="feature-name">Isolation</td>
+            <td class="col-us">Process-scoped</td>
+            <td>System-wide</td>
+            <td>System-wide</td>
+          </tr>
+          <tr>
+            <td class="feature-name">Budget enforcement</td>
+            <td class="col-us">Built-in</td>
+            <td><span class="icon-no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M6 6l12 12M6 18L18 6"/></svg></span></td>
+            <td><span class="icon-no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M6 6l12 12M6 18L18 6"/></svg></span></td>
+          </tr>
+          <tr>
+            <td class="feature-name">CI/CD gate</td>
+            <td class="col-us">Built-in</td>
+            <td><span class="icon-no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M6 6l12 12M6 18L18 6"/></svg></span></td>
+            <td><span class="icon-no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M6 6l12 12M6 18L18 6"/></svg></span></td>
+          </tr>
+          <tr>
+            <td class="feature-name">Idle noise subtraction</td>
+            <td class="col-us">Automatic</td>
+            <td><span class="icon-no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M6 6l12 12M6 18L18 6"/></svg></span></td>
+            <td><span class="icon-no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M6 6l12 12M6 18L18 6"/></svg></span></td>
+          </tr>
+          <tr>
+            <td class="feature-name">Async support</td>
+            <td class="col-us">Native</td>
+            <td>Limited</td>
+            <td><span class="icon-no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M6 6l12 12M6 18L18 6"/></svg></span></td>
+          </tr>
+          <tr>
+            <td class="feature-name">VS Code integration</td>
+            <td class="col-us">Official extension</td>
+            <td><span class="icon-no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M6 6l12 12M6 18L18 6"/></svg></span></td>
+            <td><span class="icon-no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M6 6l12 12M6 18L18 6"/></svg></span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<!-- ======================== CI/CD ======================== -->
+<section class="section section--dark">
+  <div class="container">
+    <div class="cicd__grid">
+      <div class="reveal">
+        <div class="terminal" aria-label="GitHub Action workflow file">
+          <div class="terminal__bar">
+            <span class="dots"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span></span>
+            <span class="label">.github/workflows/ci.yml</span>
+          </div>
+          <div class="terminal__body"><pre><span class="tok-cm"># .github/workflows/ci.yml</span>
+name: <span class="tok-st">Carbon Gate</span>
+
+on: [pull_request]
+
+jobs:
+  carbon-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        <span class="tok-kw">with</span>:
+          python-version: <span class="tok-st">"3.11"</span>
+
+      - name: <span class="tok-st">EcoTrace Carbon Gate</span>
+        uses: <span class="tok-st">Zwony/ecotrace@v1.3.0</span>
+        <span class="tok-kw">with</span>:
+          budget: <span class="tok-st">"10.0"</span>
+          region: <span class="tok-st">"US"</span></pre>
+          </div>
+        </div>
+      </div>
+      <div class="cicd__copy reveal">
+        <div class="eyebrow on-dark">CI/CD</div>
+        <h3 style="margin-top:1rem;">Block carbon-heavy PRs <em>before</em> they merge.</h3>
+        <p>EcoTrace ships an official GitHub Action. Set a budget, run on every PR, and fail the build when the diff regresses. The same gate is available as a CLI for any other pipeline.</p>
+        <ul>
+          <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M5 12l5 5L20 7"/></svg> Exit-code-1 failure when budget is exceeded</li>
+          <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M5 12l5 5L20 7"/></svg> Comment in the PR with the exact gCO₂ delta</li>
+          <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M5 12l5 5L20 7"/></svg> Configurable per region, per branch, per workflow</li>
+          <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M5 12l5 5L20 7"/></svg> Manual mode: <code style="font-family:var(--mono);font-size:.85em;background:rgba(62,123,87,.12);color:var(--moss-400);padding:.1rem .35rem;border-radius:3px;">ecotrace gate --budget 10.0</code></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ======================== RESOURCES / DOCS ======================== -->
+<section class="section section--dark" id="resources">
+  <div class="container">
+    <div class="section__head reveal">
+      <div class="eyebrow on-dark">Documentation</div>
+      <h2 style="color:var(--cream-50);">Everything you need, <em>one click</em> away.</h2>
+      <p style="color:rgba(246,242,231,.7);">Comprehensive guides, API references, architecture deep-dives, and a full changelog — all kept in sync with every release.</p>
+    </div>
+    <div class="resources__grid">
+      <a href="https://ecotrace.readthedocs.io/en/latest/api/" target="_blank" rel="noopener" class="resource-card reveal">
+        <div class="resource-card__icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 16 4-4-4-4M6 8l-4 4 4 4M14.5 4l-5 16"/></svg>
+        </div>
+        <h3>API Reference</h3>
+        <p>Complete typed API docs for EcoTrace, decorators, exporters, and configuration.</p>
+        <span class="resource-card__link">
+          Browse API
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+        </span>
+      </a>
+      <a href="https://ecotrace.readthedocs.io/en/latest/ARCHITECTURE/" target="_blank" rel="noopener" class="resource-card reveal">
+        <div class="resource-card__icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M18 17V9M13 17V5M8 17v-3"/></svg>
+        </div>
+        <h3>Architecture Guide</h3>
+        <p>How EcoTrace samples, calculates, and attributes carbon at the function level.</p>
+        <span class="resource-card__link">
+          Read guide
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+        </span>
+      </a>
+      <a href="https://ecotrace.readthedocs.io/en/latest/USAGE/" target="_blank" rel="noopener" class="resource-card reveal">
+        <div class="resource-card__icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+        </div>
+        <h3>Usage Guide</h3>
+        <p>Step-by-step walkthroughs for CLI, library, middleware, and report generation.</p>
+        <span class="resource-card__link">
+          Get started
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+        </span>
+      </a>
+      <a href="https://github.com/Zwony/ecotrace/blob/main/CHANGELOG.md" target="_blank" rel="noopener" class="resource-card reveal">
+        <div class="resource-card__icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8v4l3 3"/><circle cx="12" cy="12" r="10"/></svg>
+        </div>
+        <h3>Changelog</h3>
+        <p>Every feature, fix, and breaking change documented since v1.0.0.</p>
+        <span class="resource-card__link">
+          View changelog
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+        </span>
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- ======================== SPONSOR ======================== -->
+<section class="section sponsor-section" id="sponsor">
+  <div class="container">
+    <div class="sponsor__inner reveal">
+      <div class="sponsor__copy">
+        <div class="eyebrow on-dark">Support the project</div>
+        <h2 style="margin-top:1rem;">Help us keep EcoTrace <em>free</em> and growing.</h2>
+        <p>EcoTrace is MIT-licensed and community-driven. Your sponsorship funds full-time development, better documentation, and new integrations. Every dollar goes directly to making sustainable software development easier for everyone.</p>
+        <div class="sponsor__buttons">
+          <a class="btn btn--sponsor" href="https://github.com/sponsors/Zwony" target="_blank" rel="noopener">
+            <svg viewBox="0 0 24 24" fill="currentColor" style="width:16px;height:16px;"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
+            Sponsor on GitHub
+          </a>
+          <a class="btn btn--ghost" href="https://github.com/Zwony/ecotrace" target="_blank" rel="noopener">
+            <svg viewBox="0 0 24 24" fill="currentColor" style="width:16px;height:16px;"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.13c-3.2.7-3.88-1.36-3.88-1.36-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.2 1.77 1.2 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.28 1.18-3.09-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.18 1.18a11 11 0 015.78 0c2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.11 3.04.74.81 1.18 1.83 1.18 3.09 0 4.42-2.69 5.4-5.25 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56C20.21 21.38 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
+            Star on GitHub
+          </a>
+        </div>
+      </div>
+      <div class="sponsor__tiers">
+        <div class="sponsor-tier">
+          <div class="sponsor-tier__emoji">🌱</div>
+          <h4>Seedling</h4>
+          <div class="sponsor-tier__price">$5/month</div>
+          <p>Support EcoTrace, get a shoutout in the README, and early access to betas.</p>
+        </div>
+        <div class="sponsor-tier">
+          <div class="sponsor-tier__emoji">🌿</div>
+          <h4>Sapling</h4>
+          <div class="sponsor-tier__price">$15/month</div>
+          <p>Everything in Seedling, plus priority issue responses and feature requests.</p>
+        </div>
+        <div class="sponsor-tier">
+          <div class="sponsor-tier__emoji">🌳</div>
+          <h4>Oak</h4>
+          <div class="sponsor-tier__price">$50/month</div>
+          <p>Logo on the website, quarterly roadmap updates, and direct Slack access.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ======================== ECOSYSTEM ======================== -->
+<section class="section" id="docs">
+  <div class="container">
+    <div class="section__head reveal">
+      <div class="eyebrow">Ecosystem</div>
+      <h2>One library, a <em>full</em> surface.</h2>
+      <p>EcoTrace isn't a CLI you forget about after one PR. It comes with a VS Code extension, a community, and the documentation that makes it last.</p>
+    </div>
+    <div class="eco__grid">
+      <article class="eco-tile reveal">
+        <div class="eco-tile__icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M8 21V8M16 21V8M3 8h18"/></svg>
+        </div>
+        <h3>VS Code extension</h3>
+        <p>Real-time carbon footprint in your status bar as you develop. No more "ship first, measure later."</p>
+        <a class="eco-tile__cta" href="https://marketplace.visualstudio.com/items?itemName=ecotrace-team.ecotrace-monitor" target="_blank" rel="noopener">
+          Install extension
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+        </a>
+      </article>
+      <article class="eco-tile reveal">
+        <div class="eco-tile__icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>
+        </div>
+        <h3>Discord community</h3>
+        <p>Maintainers, contributors, and curious engineers sharing benchmarks, hardware data, and the occasional bad pun.</p>
+        <a class="eco-tile__cta" href="https://discord.gg/hs58XXb3Uq" target="_blank" rel="noopener">
+          Join Discord
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+        </a>
+      </article>
+      <article class="eco-tile reveal">
+        <div class="eco-tile__icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+        </div>
+        <h3>Full documentation</h3>
+        <p>Architecture deep-dives, the energy model, the science behind TDP, advanced usage, and a complete API reference.</p>
+        <a class="eco-tile__cta" href="https://ecotrace.readthedocs.io/en/latest/" target="_blank" rel="noopener">
+          Read the docs
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+        </a>
+      </article>
+    </div>
+  </div>
+</section>
+
+<!-- ======================== FOOTER ======================== -->
+<footer class="footer">
+  <div class="container">
+    <div class="footer__top">
+      <div>
+        <div class="footer__brand">
+          <img src="./imgs/logo-transparent.png" alt="" onerror="this.style.display='none'" />
+          <span>EcoTrace</span>
+        </div>
+        <p class="footer__tag">High-precision Python instrumentation for the carbon-aware generation of engineers.</p>
+      </div>
+      <div>
+        <h4>Project</h4>
+        <ul>
+          <li><a href="https://github.com/Zwony/ecotrace" target="_blank" rel="noopener">GitHub</a></li>
+          <li><a href="https://pypi.org/project/ecotrace/" target="_blank" rel="noopener">PyPI</a></li>
+          <li><a href="https://ecotrace.readthedocs.io/en/latest/" target="_blank" rel="noopener">Documentation</a></li>
+          <li><a href="https://github.com/Zwony/ecotrace/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a></li>
+        </ul>
+      </div>
+      <div>
+        <h4>Community</h4>
+        <ul>
+          <li><a href="https://discord.gg/hs58XXb3Uq" target="_blank" rel="noopener">Discord</a></li>
+          <li><a href="https://marketplace.visualstudio.com/items?itemName=ecotrace-team.ecotrace-monitor" target="_blank" rel="noopener">VS Code</a></li>
+          <li><a href="https://github.com/Zwony/ecotrace/blob/main/CONTRIBUTING.MD" target="_blank" rel="noopener">Contributing</a></li>
+          <li>
+            <a class="footer__sponsor-link" href="https://github.com/sponsors/Zwony" target="_blank" rel="noopener">
+              ♥ Sponsor Us
+            </a>
+          </li>
+        </ul>
+      </div>
+      <div>
+        <h4>Author</h4>
+        <ul>
+          <li><a href="https://github.com/Zwony" target="_blank" rel="noopener">Emre Ozkal</a></li>
+          <li><a href="mailto:ecotraceteam@gmail.com">ecotraceteam@gmail.com</a></li>
+          <li>MIT License</li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer__bottom">
+      <span>© 2026 EcoTrace Team. <em>Developed for sustainable software development practices.</em></span>
+      <span>Built with quiet forests and too much coffee.</span>
+    </div>
+  </div>
+</footer>
+
+<!-- Load core app script -->
+<script src="./js/app.js"></script>
+<script>
+  // Initial particles for the main page hero
+  document.addEventListener('DOMContentLoaded', () => {
+    if (window.initParticles) {
+      window.initParticles('heroParticles');
+    }
+  });
+</script>
+</body>
+</html>

--- a/landing/index.html
+++ b/landing/index.html
@@ -96,24 +96,64 @@
     </button>
     <div class="auth-modal__header">
       <img src="./imgs/logo.png" alt="" class="auth-modal__logo" />
-      <h2>Welcome to EcoTrace</h2>
-      <p>Sign in or create an account to access your live dashboard</p>
+      <h2 id="authTitle">Welcome Back</h2>
+      <p id="authSubtitle">Sign in to access your live dashboard</p>
+    </div>
+
+    <div class="auth-tabs">
+      <button class="auth-tab is-active" onclick="switchAuthTab('signin')">Sign In</button>
+      <button class="auth-tab" onclick="switchAuthTab('signup')">Sign Up</button>
     </div>
 
     <div class="auth-error" id="authError"></div>
 
-    <div class="auth-social auth-social--primary">
-      <button class="auth-social__btn auth-social__btn--github" onclick="socialAuth('github')">
+    <!-- Sign In Form -->
+    <form class="auth-form is-active" data-form="signin" id="signinForm" onsubmit="handleSignIn(event)">
+      <div class="form-group">
+        <label for="signin-email">Email</label>
+        <input type="email" id="signin-email" placeholder="you@example.com" required autocomplete="email" />
+      </div>
+      <div class="form-group">
+        <label for="signin-password">Password</label>
+        <input type="password" id="signin-password" placeholder="••••••••" required autocomplete="current-password" />
+        <button type="button" class="toggle-pw" onclick="togglePassword('signin-password', this)" aria-label="Toggle password visibility">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+        </button>
+      </div>
+      <button type="submit" class="auth-submit">Sign In</button>
+    </form>
+
+    <!-- Sign Up Form -->
+    <form class="auth-form" data-form="signup" id="signupForm" onsubmit="handleSignUp(event)">
+      <div class="form-group">
+        <label for="signup-name">Full Name</label>
+        <input type="text" id="signup-name" placeholder="Emre Ozkal" required autocomplete="name" />
+      </div>
+      <div class="form-group">
+        <label for="signup-email">Email</label>
+        <input type="email" id="signup-email" placeholder="you@example.com" required autocomplete="email" />
+      </div>
+      <div class="form-group">
+        <label for="signup-password">Password</label>
+        <input type="password" id="signup-password" placeholder="Min 8 characters" required minlength="8" autocomplete="new-password" />
+        <button type="button" class="toggle-pw" onclick="togglePassword('signup-password', this)" aria-label="Toggle password visibility">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+        </button>
+      </div>
+      <button type="submit" class="auth-submit">Create Account</button>
+    </form>
+
+    <div class="auth-divider">or continue with</div>
+    <div class="auth-social">
+      <button onclick="socialAuth('github')">
         <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.13c-3.2.7-3.88-1.36-3.88-1.36-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.2 1.77 1.2 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.28 1.18-3.09-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.18 1.18a11 11 0 015.78 0c2.2-1.49 3.17-1.18 3.17-1.18.62 1.58.23 2.75.11 3.04.74.81 1.18 1.83 1.18 3.09 0 4.42-2.69 5.4-5.25 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56C20.21 21.38 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
-        Continue with GitHub
+        GitHub
       </button>
-      <button class="auth-social__btn auth-social__btn--google" onclick="socialAuth('google')">
+      <button onclick="socialAuth('google')">
         <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"/><path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/><path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/><path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/></svg>
-        Continue with Google
+        Google
       </button>
     </div>
-
-    <p class="auth-modal__terms">By continuing, you agree to our <a href="#" onclick="closeAuthModal()">Terms of Service</a> and <a href="#" onclick="closeAuthModal()">Privacy Policy</a>.</p>
   </div>
 </div>
 

--- a/landing/js/app.js
+++ b/landing/js/app.js
@@ -1,9 +1,8 @@
 /* ============================================================
    EcoTrace — Application Core & Authentication
-   OAuth-only: GitHub and Google via FastAPI backend
+   Supports email/password + GitHub/Google OAuth
    ============================================================ */
 
-// API Backend Base URL — empty string means same origin in production
 const BACKEND_URL = (
   window.location.hostname === 'localhost' ||
   window.location.hostname === '127.0.0.1' ||
@@ -54,7 +53,7 @@ if (hamburger && mobileNav) {
 }
 
 /* ============================================================
-   Tab switcher
+   Tab switcher (quick start tabs)
    ============================================================ */
 document.querySelectorAll('.tab').forEach(t => {
   t.addEventListener('click', () => {
@@ -71,10 +70,7 @@ document.querySelectorAll('.tab').forEach(t => {
    ============================================================ */
 const io = new IntersectionObserver((entries) => {
   entries.forEach(e => {
-    if (e.isIntersecting) {
-      e.target.classList.add('is-in');
-      io.unobserve(e.target);
-    }
+    if (e.isIntersecting) { e.target.classList.add('is-in'); io.unobserve(e.target); }
   });
 }, { threshold: 0.15, rootMargin: '0px 0px -60px 0px' });
 document.querySelectorAll('.reveal').forEach(el => io.observe(el));
@@ -110,12 +106,12 @@ const countIO = new IntersectionObserver((entries) => {
 document.querySelectorAll('.stat__num[data-count]').forEach(el => countIO.observe(el));
 
 /* ============================================================
-   Auth Modal
+   Auth Modal — open / close
    ============================================================ */
 const authOverlay = document.getElementById('authOverlay');
-const authError = document.getElementById('authError');
-const navAuthBtn = document.getElementById('navAuthBtn');
-const navUser = document.getElementById('navUser');
+const authError   = document.getElementById('authError');
+const navAuthBtn  = document.getElementById('navAuthBtn');
+const navUser     = document.getElementById('navUser');
 
 window.openAuthModal = function () {
   if (authOverlay) {
@@ -133,16 +129,106 @@ window.closeAuthModal = function () {
 };
 
 if (authOverlay) {
-  authOverlay.addEventListener('click', (e) => {
-    if (e.target === authOverlay) closeAuthModal();
-  });
-  document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape') closeAuthModal();
-  });
+  authOverlay.addEventListener('click', (e) => { if (e.target === authOverlay) closeAuthModal(); });
+  document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeAuthModal(); });
 }
 
 /* ============================================================
-   OAuth Sign-In — redirects to FastAPI OAuth endpoints
+   Auth Modal — tab switcher (Sign In / Sign Up)
+   ============================================================ */
+window.switchAuthTab = function (tab) {
+  const authTabs  = document.querySelectorAll('.auth-tab');
+  const authForms = document.querySelectorAll('.auth-form');
+  const title     = document.getElementById('authTitle');
+  const subtitle  = document.getElementById('authSubtitle');
+  if (authError) authError.classList.remove('is-visible');
+
+  authTabs.forEach(t => t.classList.remove('is-active'));
+  authForms.forEach(f => f.classList.remove('is-active'));
+
+  if (tab === 'signin') {
+    authTabs[0].classList.add('is-active');
+    document.querySelector('[data-form="signin"]').classList.add('is-active');
+    if (title)    title.textContent    = 'Welcome Back';
+    if (subtitle) subtitle.textContent = 'Sign in to access your live dashboard';
+  } else {
+    authTabs[1].classList.add('is-active');
+    document.querySelector('[data-form="signup"]').classList.add('is-active');
+    if (title)    title.textContent    = 'Create Account';
+    if (subtitle) subtitle.textContent = 'Join EcoTrace to start tracking your carbon';
+  }
+};
+
+function showAuthError(msg) {
+  if (authError) {
+    authError.textContent = msg;
+    authError.classList.add('is-visible');
+  }
+}
+
+/* ============================================================
+   Sign Up (email + password)
+   ============================================================ */
+window.handleSignUp = async function (e) {
+  e.preventDefault();
+  const name  = document.getElementById('signup-name').value.trim();
+  const email = document.getElementById('signup-email').value.trim();
+  const pw    = document.getElementById('signup-password').value;
+
+  try {
+    const res  = await fetch(`${BACKEND_URL}/api/signup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, email, password: pw }),
+    });
+    const data = await res.json();
+    if (res.ok) {
+      localStorage.setItem('ecotrace_token', data.access_token);
+      closeAuthModal();
+      await checkUserAuth();
+      window.location.href = './dashboard.html';
+    } else {
+      showAuthError(data.detail || 'Sign up failed. Please try again.');
+    }
+  } catch {
+    showAuthError('Could not reach the server. Please try again.');
+  }
+};
+
+/* ============================================================
+   Sign In (email + password)
+   ============================================================ */
+window.handleSignIn = async function (e) {
+  e.preventDefault();
+  const email = document.getElementById('signin-email').value.trim();
+  const pw    = document.getElementById('signin-password').value;
+
+  try {
+    const body = new URLSearchParams();
+    body.append('username', email);
+    body.append('password', pw);
+
+    const res  = await fetch(`${BACKEND_URL}/api/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+    const data = await res.json();
+    if (res.ok) {
+      localStorage.setItem('ecotrace_token', data.access_token);
+      closeAuthModal();
+      await checkUserAuth();
+      window.location.href = './dashboard.html';
+    } else {
+      showAuthError(data.detail || 'Incorrect email or password.');
+    }
+  } catch {
+    showAuthError('Could not reach the server. Please try again.');
+  }
+};
+
+/* ============================================================
+   OAuth — GitHub / Google
    ============================================================ */
 window.socialAuth = function (provider) {
   window.location.href = `${BACKEND_URL}/login/${provider}`;
@@ -160,49 +246,59 @@ window.signOut = function () {
 };
 
 /* ============================================================
-   Auth State Check (JWT via /api/me)
+   Password visibility toggle
+   ============================================================ */
+window.togglePassword = function (inputId, btn) {
+  const input = document.getElementById(inputId);
+  if (input.type === 'password') {
+    input.type = 'text';
+    btn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>';
+  } else {
+    input.type = 'password';
+    btn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>';
+  }
+};
+
+/* ============================================================
+   Auth state check via /api/me
    ============================================================ */
 window.checkUserAuth = async function () {
   const token = localStorage.getItem('ecotrace_token');
-  if (!token) {
-    updateAuthUI(null);
-    return null;
-  }
+  if (!token) { updateAuthUI(null); return null; }
+
   try {
     const res = await fetch(`${BACKEND_URL}/api/me`, {
-      headers: { 'Authorization': `Bearer ${token}` }
+      headers: { 'Authorization': `Bearer ${token}` },
     });
     if (res.ok) {
       const user = await res.json();
       updateAuthUI(user);
       return user;
     }
-    // Token invalid or expired
     localStorage.removeItem('ecotrace_token');
     updateAuthUI(null);
     return null;
-  } catch (err) {
-    console.error('Auth check failed:', err);
+  } catch {
     updateAuthUI(null);
     return null;
   }
 };
 
 /* ============================================================
-   Update nav UI based on auth state
+   Nav UI — update based on auth state
    ============================================================ */
 function updateAuthUI(user) {
   if (user) {
     if (navAuthBtn) navAuthBtn.style.display = 'none';
-    if (navUser) navUser.classList.add('is-visible');
+    if (navUser)    navUser.classList.add('is-visible');
     const initials = user.name.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2);
-    const avatar = document.getElementById('navUserAvatar');
+    const avatar   = document.getElementById('navUserAvatar');
     const nameSpan = document.getElementById('navUserName');
-    if (avatar) avatar.textContent = initials;
+    if (avatar)   avatar.textContent   = initials;
     if (nameSpan) nameSpan.textContent = user.name.split(' ')[0];
   } else {
     if (navAuthBtn) navAuthBtn.style.display = '';
-    if (navUser) navUser.classList.remove('is-visible');
+    if (navUser)    navUser.classList.remove('is-visible');
   }
 }
 
@@ -215,7 +311,7 @@ window.toggleUserDropdown = function () {
 };
 
 document.addEventListener('click', (e) => {
-  const user = document.getElementById('navUser');
+  const user     = document.getElementById('navUser');
   const dropdown = document.getElementById('navUserDropdown');
   if (user && !user.contains(e.target) && dropdown) {
     dropdown.classList.remove('is-open');
@@ -223,7 +319,7 @@ document.addEventListener('click', (e) => {
 });
 
 /* ============================================================
-   Particle system helper (shared by index + dashboard)
+   Particle system (shared by index + dashboard)
    ============================================================ */
 window.initParticles = function (canvasId) {
   const canvas = document.getElementById(canvasId);
@@ -234,27 +330,19 @@ window.initParticles = function (canvasId) {
 
   function resize() {
     const rect = canvas.parentElement.getBoundingClientRect();
-    w = canvas.width = rect.width;
+    w = canvas.width  = rect.width;
     h = canvas.height = rect.height;
   }
-
   function createParticle() {
     return {
       x: Math.random() * w, y: Math.random() * h,
       r: Math.random() * 2 + 0.5,
-      dx: (Math.random() - 0.5) * 0.3,
-      dy: (Math.random() - 0.5) * 0.3,
+      dx: (Math.random() - 0.5) * 0.3, dy: (Math.random() - 0.5) * 0.3,
       alpha: Math.random() * 0.4 + 0.1,
-      color: Math.random() > 0.5 ? '62,123,87' : '212,160,74'
+      color: Math.random() > 0.5 ? '62,123,87' : '212,160,74',
     };
   }
-
-  function init() {
-    resize();
-    particles = [];
-    for (let i = 0; i < count; i++) particles.push(createParticle());
-  }
-
+  function init() { resize(); particles = []; for (let i = 0; i < count; i++) particles.push(createParticle()); }
   function draw() {
     ctx.clearRect(0, 0, w, h);
     particles.forEach(p => {
@@ -263,7 +351,7 @@ window.initParticles = function (canvasId) {
       if (p.y < 0 || p.y > h) p.dy *= -1;
       ctx.beginPath();
       ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
-      ctx.fillStyle = `rgba(${p.color}, ${p.alpha})`;
+      ctx.fillStyle = `rgba(${p.color},${p.alpha})`;
       ctx.fill();
     });
     for (let i = 0; i < particles.length; i++) {
@@ -275,7 +363,7 @@ window.initParticles = function (canvasId) {
           ctx.beginPath();
           ctx.moveTo(particles[i].x, particles[i].y);
           ctx.lineTo(particles[j].x, particles[j].y);
-          ctx.strokeStyle = `rgba(62, 123, 87, ${0.08 * (1 - dist / 120)})`;
+          ctx.strokeStyle = `rgba(62,123,87,${0.08 * (1 - dist / 120)})`;
           ctx.lineWidth = 0.5;
           ctx.stroke();
         }
@@ -283,27 +371,26 @@ window.initParticles = function (canvasId) {
     }
     requestAnimationFrame(draw);
   }
-
   init();
   window.addEventListener('resize', resize);
   draw();
 };
 
 /* ============================================================
-   OAuth Callback — extract #token from redirect fragment
-   Must run before checkUserAuth to avoid a flash of signed-out UI
+   OAuth Callback — extract #token from redirect fragment.
+   Runs synchronously before checkUserAuth so there's no
+   flash of signed-out state on the dashboard page.
    ============================================================ */
 (function handleOAuthCallback() {
   const params = new URLSearchParams(window.location.hash.slice(1));
-  const token = params.get('token');
+  const token  = params.get('token');
   if (token) {
     localStorage.setItem('ecotrace_token', token);
-    // Remove the fragment so the token never shows in history or server logs
+    // Remove fragment so it never appears in logs or history
     window.history.replaceState({}, document.title, window.location.pathname);
-    // Navigate to dashboard — checkUserAuth will run there
     window.location.replace('./dashboard.html');
   }
 })();
 
-// Check auth on every page load (after OAuth callback check above)
+// Run auth check on every page load
 checkUserAuth();

--- a/landing/js/app.js
+++ b/landing/js/app.js
@@ -1,0 +1,309 @@
+/* ============================================================
+   EcoTrace — Application Core & Authentication
+   OAuth-only: GitHub and Google via FastAPI backend
+   ============================================================ */
+
+// API Backend Base URL — empty string means same origin in production
+const BACKEND_URL = (
+  window.location.hostname === 'localhost' ||
+  window.location.hostname === '127.0.0.1' ||
+  window.location.protocol === 'file:'
+) ? 'http://localhost:8000' : '';
+
+/* ============================================================
+   Scroll Progress Indicator
+   ============================================================ */
+const scrollProgressBar = document.getElementById('scrollProgress');
+if (scrollProgressBar) {
+  function updateScrollProgress() {
+    const h = document.documentElement;
+    const scrollTop = h.scrollTop || document.body.scrollTop;
+    const scrollHeight = h.scrollHeight - h.clientHeight;
+    const pct = scrollHeight > 0 ? (scrollTop / scrollHeight) * 100 : 0;
+    scrollProgressBar.style.width = pct + '%';
+  }
+  window.addEventListener('scroll', updateScrollProgress, { passive: true });
+}
+
+/* ============================================================
+   Nav scroll state
+   ============================================================ */
+const nav = document.getElementById('nav');
+if (nav) {
+  const onScroll = () => nav.classList.toggle('is-scrolled', window.scrollY > 16);
+  window.addEventListener('scroll', onScroll, { passive: true });
+  onScroll();
+}
+
+/* ============================================================
+   Hamburger menu
+   ============================================================ */
+const hamburger = document.getElementById('hamburger');
+const mobileNav = document.getElementById('mobileNav');
+if (hamburger && mobileNav) {
+  window.toggleMobileNav = function () {
+    hamburger.classList.toggle('is-open');
+    mobileNav.classList.toggle('is-open');
+    document.body.style.overflow = mobileNav.classList.contains('is-open') ? 'hidden' : '';
+  };
+  window.closeMobileNav = function () {
+    hamburger.classList.remove('is-open');
+    mobileNav.classList.remove('is-open');
+    document.body.style.overflow = '';
+  };
+}
+
+/* ============================================================
+   Tab switcher
+   ============================================================ */
+document.querySelectorAll('.tab').forEach(t => {
+  t.addEventListener('click', () => {
+    document.querySelectorAll('.tab').forEach(x => x.classList.remove('is-active'));
+    document.querySelectorAll('.tab__panel').forEach(p => p.classList.remove('is-active'));
+    t.classList.add('is-active');
+    const panel = document.querySelector(`[data-panel="${t.dataset.tab}"]`);
+    if (panel) panel.classList.add('is-active');
+  });
+});
+
+/* ============================================================
+   Scroll reveal
+   ============================================================ */
+const io = new IntersectionObserver((entries) => {
+  entries.forEach(e => {
+    if (e.isIntersecting) {
+      e.target.classList.add('is-in');
+      io.unobserve(e.target);
+    }
+  });
+}, { threshold: 0.15, rootMargin: '0px 0px -60px 0px' });
+document.querySelectorAll('.reveal').forEach(el => io.observe(el));
+
+/* ============================================================
+   Count-up animation
+   ============================================================ */
+const easeOut = (t) => 1 - Math.pow(1 - t, 3);
+const countUp = (el) => {
+  const target = parseFloat(el.dataset.count);
+  const suffix = el.dataset.suffix || '';
+  const duration = 1200;
+  const start = performance.now();
+  const tick = (now) => {
+    const t = Math.min(1, (now - start) / duration);
+    if (el.firstChild && el.firstChild.nodeType === 3) {
+      el.firstChild.nodeValue = Math.round(target * easeOut(t)) + suffix;
+    }
+    if (t < 1) requestAnimationFrame(tick);
+  };
+  if (el.firstChild && el.firstChild.nodeType === 3) {
+    requestAnimationFrame(tick);
+  } else {
+    el.insertBefore(document.createTextNode('0' + suffix), el.firstChild);
+    requestAnimationFrame(tick);
+  }
+};
+const countIO = new IntersectionObserver((entries) => {
+  entries.forEach(e => {
+    if (e.isIntersecting) { countUp(e.target); countIO.unobserve(e.target); }
+  });
+}, { threshold: 0.5 });
+document.querySelectorAll('.stat__num[data-count]').forEach(el => countIO.observe(el));
+
+/* ============================================================
+   Auth Modal
+   ============================================================ */
+const authOverlay = document.getElementById('authOverlay');
+const authError = document.getElementById('authError');
+const navAuthBtn = document.getElementById('navAuthBtn');
+const navUser = document.getElementById('navUser');
+
+window.openAuthModal = function () {
+  if (authOverlay) {
+    authOverlay.classList.add('is-open');
+    document.body.style.overflow = 'hidden';
+    if (authError) authError.classList.remove('is-visible');
+  }
+};
+
+window.closeAuthModal = function () {
+  if (authOverlay) {
+    authOverlay.classList.remove('is-open');
+    document.body.style.overflow = '';
+  }
+};
+
+if (authOverlay) {
+  authOverlay.addEventListener('click', (e) => {
+    if (e.target === authOverlay) closeAuthModal();
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') closeAuthModal();
+  });
+}
+
+/* ============================================================
+   OAuth Sign-In — redirects to FastAPI OAuth endpoints
+   ============================================================ */
+window.socialAuth = function (provider) {
+  window.location.href = `${BACKEND_URL}/login/${provider}`;
+};
+
+/* ============================================================
+   Sign Out
+   ============================================================ */
+window.signOut = function () {
+  localStorage.removeItem('ecotrace_token');
+  updateAuthUI(null);
+  if (window.location.pathname.includes('dashboard.html')) {
+    window.location.href = './index.html';
+  }
+};
+
+/* ============================================================
+   Auth State Check (JWT via /api/me)
+   ============================================================ */
+window.checkUserAuth = async function () {
+  const token = localStorage.getItem('ecotrace_token');
+  if (!token) {
+    updateAuthUI(null);
+    return null;
+  }
+  try {
+    const res = await fetch(`${BACKEND_URL}/api/me`, {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (res.ok) {
+      const user = await res.json();
+      updateAuthUI(user);
+      return user;
+    }
+    // Token invalid or expired
+    localStorage.removeItem('ecotrace_token');
+    updateAuthUI(null);
+    return null;
+  } catch (err) {
+    console.error('Auth check failed:', err);
+    updateAuthUI(null);
+    return null;
+  }
+};
+
+/* ============================================================
+   Update nav UI based on auth state
+   ============================================================ */
+function updateAuthUI(user) {
+  if (user) {
+    if (navAuthBtn) navAuthBtn.style.display = 'none';
+    if (navUser) navUser.classList.add('is-visible');
+    const initials = user.name.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2);
+    const avatar = document.getElementById('navUserAvatar');
+    const nameSpan = document.getElementById('navUserName');
+    if (avatar) avatar.textContent = initials;
+    if (nameSpan) nameSpan.textContent = user.name.split(' ')[0];
+  } else {
+    if (navAuthBtn) navAuthBtn.style.display = '';
+    if (navUser) navUser.classList.remove('is-visible');
+  }
+}
+
+/* ============================================================
+   User dropdown toggle
+   ============================================================ */
+window.toggleUserDropdown = function () {
+  const dropdown = document.getElementById('navUserDropdown');
+  if (dropdown) dropdown.classList.toggle('is-open');
+};
+
+document.addEventListener('click', (e) => {
+  const user = document.getElementById('navUser');
+  const dropdown = document.getElementById('navUserDropdown');
+  if (user && !user.contains(e.target) && dropdown) {
+    dropdown.classList.remove('is-open');
+  }
+});
+
+/* ============================================================
+   Particle system helper (shared by index + dashboard)
+   ============================================================ */
+window.initParticles = function (canvasId) {
+  const canvas = document.getElementById(canvasId);
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  let w, h, particles = [];
+  const count = 40;
+
+  function resize() {
+    const rect = canvas.parentElement.getBoundingClientRect();
+    w = canvas.width = rect.width;
+    h = canvas.height = rect.height;
+  }
+
+  function createParticle() {
+    return {
+      x: Math.random() * w, y: Math.random() * h,
+      r: Math.random() * 2 + 0.5,
+      dx: (Math.random() - 0.5) * 0.3,
+      dy: (Math.random() - 0.5) * 0.3,
+      alpha: Math.random() * 0.4 + 0.1,
+      color: Math.random() > 0.5 ? '62,123,87' : '212,160,74'
+    };
+  }
+
+  function init() {
+    resize();
+    particles = [];
+    for (let i = 0; i < count; i++) particles.push(createParticle());
+  }
+
+  function draw() {
+    ctx.clearRect(0, 0, w, h);
+    particles.forEach(p => {
+      p.x += p.dx; p.y += p.dy;
+      if (p.x < 0 || p.x > w) p.dx *= -1;
+      if (p.y < 0 || p.y > h) p.dy *= -1;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+      ctx.fillStyle = `rgba(${p.color}, ${p.alpha})`;
+      ctx.fill();
+    });
+    for (let i = 0; i < particles.length; i++) {
+      for (let j = i + 1; j < particles.length; j++) {
+        const dx = particles[i].x - particles[j].x;
+        const dy = particles[i].y - particles[j].y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist < 120) {
+          ctx.beginPath();
+          ctx.moveTo(particles[i].x, particles[i].y);
+          ctx.lineTo(particles[j].x, particles[j].y);
+          ctx.strokeStyle = `rgba(62, 123, 87, ${0.08 * (1 - dist / 120)})`;
+          ctx.lineWidth = 0.5;
+          ctx.stroke();
+        }
+      }
+    }
+    requestAnimationFrame(draw);
+  }
+
+  init();
+  window.addEventListener('resize', resize);
+  draw();
+};
+
+/* ============================================================
+   OAuth Callback — extract #token from redirect fragment
+   Must run before checkUserAuth to avoid a flash of signed-out UI
+   ============================================================ */
+(function handleOAuthCallback() {
+  const params = new URLSearchParams(window.location.hash.slice(1));
+  const token = params.get('token');
+  if (token) {
+    localStorage.setItem('ecotrace_token', token);
+    // Remove the fragment so the token never shows in history or server logs
+    window.history.replaceState({}, document.title, window.location.pathname);
+    // Navigate to dashboard — checkUserAuth will run there
+    window.location.replace('./dashboard.html');
+  }
+})();
+
+// Check auth on every page load (after OAuth callback check above)
+checkUserAuth();


### PR DESCRIPTION
## Summary

Switches the web app to GitHub + Google OAuth only, and prepares everything for server deployment.

### Auth changes
- Removed \/api/signup\ and \/api/token\ (password) endpoints from backend
- Removed \users_db.json\ legacy artifact
- Cleaned up \uth.py\ — no more bcrypt/passlib dependency for password hashing
- Auth modal now shows only **Continue with GitHub** and **Continue with Google** buttons
- Fixed \dashboard.html\: removed hardcoded \is-visible\ on \
avUser\ (logged-out users were seeing the nav as signed-in)
- Fixed OAuth callback race condition in \pp.js\

### Deployment
- \ackend/Dockerfile\ — builds FastAPI + serves landing as static files
- \docker-compose.yml\ — PostgreSQL + API services with health checks
- \.env.example\ — all required env vars documented at repo root
- \ackend/DEPLOYMENT.md\ — step-by-step: Docker, Nginx, HTTPS, Cloudflare, ufw firewall, OAuth app setup